### PR TITLE
feat: Add `aitag` script to generate git tag messages using an LLM

### DIFF
--- a/aitag
+++ b/aitag
@@ -145,9 +145,10 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-if [ -n "$MODEL" ]; then
-    export LLM_MODEL="$MODEL"
+if [ -z "$MODEL" ]; then
+    MODEL=$(llm models default)
 fi
+export LLM_MODEL="$MODEL"
 
 trap cleanup SIGINT
 
@@ -187,7 +188,7 @@ else
     DIFF=$(git diff "$LAST_TAG"..."$COMMIT")
 fi
 
-spin_animation "Generating tag message" &
+spin_animation "Generating tag message using $MODEL" &
 SPIN_PID=$!
 
 PROMPT_CONTENT="$(cat "$PROMPT_FILE")"

--- a/aitag
+++ b/aitag
@@ -90,8 +90,8 @@ show_help() {
 
 init_config() {
     if [ ! -f "$DEFAULT_PROMPT_FILE" ]; then
-        brew_title_prompt=$(brew --prefix)/share/gitai/prompts/aitag-prompt.txt
-        if [ ! -f "$brew_title_prompt" ]; then
+        brew_prompt=$(brew --prefix)/share/gitai/prompts/aitag-prompt.txt
+        if [ ! -f "$brew_prompt" ]; then
             echo "Can't find a default configuration file. Please create one at $DEFAULT_PROMPT_FILE" >&2
             exit 1
         fi

--- a/aitag
+++ b/aitag
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# Thanks Harper Reed https://harper.blog/2024/03/11/use-an-llm-to-automagically-generate-meaningful-git-commit-messages/
+
+# ANSI color codes for styling the output
+RED='\033[0;31m'    # Sets text to red
+GREEN='\033[0;32m'  # Sets text to green
+YELLOW='\033[0;33m' # Sets text to yellow
+BLUE='\033[0;34m'   # Sets text to blue
+NC='\033[0m'        # Resets the text color to default, no color
+
+DEFAULT_PROMPT_FILE=~/.config/gitai/prompts/aitag-prompt.txt
+
+check_required_commands() {
+    local missing=0
+    for cmd in git llm; do
+        if ! command -v "$cmd" >/dev/null 2>&1; then
+            echo "Error: $cmd is not installed"
+            missing=$((missing + 1))
+        fi
+    done
+    return $missing
+}
+
+cleanup() {
+    echo -e "\n${RED}Script interrupted. Cleaning up...${NC}"
+    kill_spin
+    tput cnorm # Show the cursor
+    exit 1
+}
+
+# Function to display a spinning animation during the LLM processing
+spin_animation() {
+    local msg="$1"
+    # Only show animation if output is going to a terminal
+    if ! [ -t 1 ]; then
+        echo "$1..." # Just show the message without animation
+        return
+    fi
+
+    # Array of spinner characters for the animation
+    local spinner=("⠋" "⠙" "⠹" "⠸" "⠼" "⠴" "⠦" "⠧" "⠇" "⠏")
+    # Infinite loop to keep the animation running
+    while true; do
+        for i in "${spinner[@]}"; do
+            tput civis                                    # Hide the cursor to enhance the animation appearance
+            tput el1                                      # Clear the line from the cursor to the beginning to display the spinner
+            printf "\r${YELLOW}%s${NC} %s..." "$i" "$msg" # Print the spinner and message
+            sleep 0.1                                     # Delay to control the speed of the animation
+            tput cub $((${#msg} + 5))                     # Move the cursor back to reset the spinner position
+        done
+    done
+}
+
+kill_spin() {
+    if [ -n "$SPIN_PID" ]; then
+        kill $SPIN_PID
+        wait $SPIN_PID 2>/dev/null # Wait for the process to terminate and suppress error messages
+        SPIN_PID=
+        printf "\n"
+    fi
+}
+
+is_git_repo() {
+    git rev-parse --is-inside-work-tree >/dev/null 2>&1
+}
+
+show_help() {
+    echo "Usage: aitag [OPTIONS] TAG_NAME [COMMIT]"
+    echo
+    echo "FLAGS:"
+    echo "  -a, --annotate        Create an annotated tag"
+    echo "  -s, --sign            Create a signed tag"
+    echo "  -u, --local-user USER Create tag with specific user"
+    echo "  --prompt FILE         Use custom prompt file"
+    echo "  --model MODEL         Specify LLM model to use"
+    echo "  -h, --help            Show this help message"
+    echo
+    echo "ENVIRONMENT VARIABLES:"
+    echo "  GITAI_TAG_PROMPT       Default prompt file path (default: $DEFAULT_PROMPT_FILE)"
+    echo "  GITAI_MODEL            Set default LLM model for PR generation"
+    echo
+    echo "EXAMPLES:"
+    echo "  aitag v1.0.0                    # Tag HEAD commit as v1.0.0"
+    echo "  aitag -a v1.0.0 abc1234         # Create annotated tag for specific commit"
+    echo "  aitag --model gpt-4 v1.0.0      # Use gpt-4 model for message generation"
+    echo "  GITAI_MODEL=gpt-4 aitag v1.0.0  # Use gpt-4 via environment variable"
+}
+
+init_config() {
+    if [ ! -f "$DEFAULT_PROMPT_FILE" ]; then
+        brew_title_prompt=$(brew --prefix)/share/gitai/prompts/aitag-prompt.txt
+        if [ ! -f "$brew_title_prompt" ]; then
+            echo "Can't find a default configuration file. Please create one at $DEFAULT_PROMPT_FILE" >&2
+            exit 1
+        fi
+    fi
+}
+
+init_config
+
+TAG_OPTS=()
+PROMPT=${GITAI_TAG_PROMPT:-$DEFAULT_PROMPT_FILE}
+MODEL=${GITAI_MODEL}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -h | --help)
+            show_help
+            exit
+            ;;
+        -a | --annotate)
+            TAG_OPTS+=("$1")
+            shift
+            ;;
+        -s | --sign)
+            TAG_OPTS+=("$1")
+            shift
+            ;;
+        -u | --local-user)
+            TAG_OPTS+=("-u" "$2")
+            shift 2
+            ;;
+        --prompt)
+            PROMPT="$2"
+            shift 2
+            ;;
+        --model)
+            MODEL="$2"
+            shift 2
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+if [ -n "$MODEL" ]; then
+    export LLM_MODEL="$MODEL"
+fi
+
+trap cleanup SIGINT
+
+if ! check_required_commands; then
+    echo "Please install missing commands before proceeding" >&2
+    exit 1
+fi
+
+if ! is_git_repo; then
+    echo "Not in a Git repository" >&2
+    exit 1
+fi
+
+if [ -z "$1" ]; then
+    exit 1
+fi
+
+TAG_NAME="$1"
+
+COMMIT=$2
+if [ -z "$2" ]; then
+    COMMIT=HEAD
+fi
+
+if ! git rev-parse --verify "$COMMIT" >/dev/null 2>&1; then
+    echo -e "${RED}Error: '$COMMIT' is not a valid commit or branch${NC}" >&2
+    exit 1
+fi
+
+LAST_TAG=$(git tag | sort | tail -n1)
+
+DIFF=
+if [ -z "$LAST_TAG" ]; then
+    # If there no tag, all file are used to generate the message
+    DIFF=$(git ls-files | xargs cat)
+else
+    DIFF=$(git diff "$LAST_TAG"..."$COMMIT")
+fi
+
+spin_animation "Generating tag message" &
+SPIN_PID=$!
+MSG=$(echo "$DIFF" | llm -s "$(cat "$PROMPT")")
+kill_spin
+
+TEMP=$(mktemp -q)
+if [[ -z "$TEMP" || ! -f "$TEMP" ]]; then
+    echo "Error: Failed to create temporary file." >&2
+    exit 1
+fi
+trap 'rm -f "${TEMP}"' EXIT SIGINT TERM
+echo "$MSG" >"$TEMP"
+${EDITOR:-vi} "$TEMP"
+
+read -p "Create tag:$TAG_NAME with these details? [y/N] " confirm
+if [[ $confirm =~ ^[Yy]$ ]]; then
+    git tag "${TAG_OPTS[@]}" -F "$TEMP" "$TAG_NAME" "$COMMIT"
+else
+    echo "Tag creation cancelled"
+fi
+
+rm -f "$TEMP"

--- a/aitag
+++ b/aitag
@@ -73,11 +73,13 @@ show_help() {
     echo "  -u, --local-user USER Create tag with specific user"
     echo "  --prompt FILE         Use custom prompt file"
     echo "  --model MODEL         Specify LLM model to use"
+    echo "  --lang <lang>         Generate content in specified language (default: English)"
     echo "  -h, --help            Show this help message"
     echo
     echo "ENVIRONMENT VARIABLES:"
     echo "  GITAI_TAG_PROMPT       Default prompt file path (default: $DEFAULT_PROMPT_FILE)"
     echo "  GITAI_MODEL            Set default LLM model for PR generation"
+    echo "  GITAI_LANG             Set default language for generation"
     echo
     echo "EXAMPLES:"
     echo "  aitag v1.0.0                    # Tag HEAD commit as v1.0.0"
@@ -99,8 +101,9 @@ init_config() {
 init_config
 
 TAG_OPTS=()
-PROMPT=${GITAI_TAG_PROMPT:-$DEFAULT_PROMPT_FILE}
+PROMPT_FILE=${GITAI_TAG_PROMPT:-$DEFAULT_PROMPT_FILE}
 MODEL=${GITAI_MODEL}
+LANGUAGE=${GITAI_LANGUAGE:-English}
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -121,12 +124,20 @@ while [[ $# -gt 0 ]]; do
             shift 2
             ;;
         --prompt)
-            PROMPT="$2"
+            PROMPT_FILE="$2"
             shift 2
             ;;
         --model)
             MODEL="$2"
             shift 2
+            ;;
+        --lang)
+            LANGUAGE="$2"
+            shift 2
+            ;;
+        --)
+            shift
+            break
             ;;
         *)
             break
@@ -178,7 +189,17 @@ fi
 
 spin_animation "Generating tag message" &
 SPIN_PID=$!
-MSG=$(echo "$DIFF" | llm -s "$(cat "$PROMPT")")
+
+PROMPT_CONTENT="$(cat "$PROMPT_FILE")"
+PROMPT=$(
+    cat <<EOF
+All non-code text responses must be written in the $LANGUAGE language indicated.
+
+$PROMPT_CONTENT
+EOF
+)
+
+MSG=$(echo "$DIFF" | llm -s "$PROMPT")
 kill_spin
 
 TEMP=$(mktemp -q)

--- a/aitag
+++ b/aitag
@@ -178,7 +178,7 @@ if ! git rev-parse --verify "$COMMIT" >/dev/null 2>&1; then
     exit 1
 fi
 
-LAST_TAG=$(git tag | sort | tail -n1)
+LAST_TAG=$(git tag --sort=-v:refname | head -n1)
 
 DIFF=
 if [ -z "$LAST_TAG" ]; then

--- a/completions/_aipr
+++ b/completions/_aipr
@@ -12,7 +12,7 @@ _aipr() {
         '--prompt-body[Path to PR body prompt template]:file:_files' \
         '--model[LLM model to use for generating PR content]:model:->models' \
         '--update-title[Update PR title when editing existing PR]::' \
-        '--lang[Generate content in specified language (default: English)]::'
+        '--lang[Generate content in specified language (default: English)]:language:'
 
     case $state in
         remotes)

--- a/completions/_aitag
+++ b/completions/_aitag
@@ -8,7 +8,8 @@ _aitag() {
         {-s,--sign}'[Create signed tag]' \
         {-u,--local-user=}'[Create tag with specific user]:user:->users' \
         '--prompt=[Use custom prompt file]:prompt file:_files' \
-        '--model=[Specify LLM model to use]:model:->models'
+        '--model=[Specify LLM model to use]:model:->models' \
+        '--lang[Generate content in specified language (default: English)]::'
 
     case "$state" in
         users)

--- a/completions/_aitag
+++ b/completions/_aitag
@@ -9,7 +9,7 @@ _aitag() {
         {-u,--local-user=}'[Create tag with specific user]:user:->users' \
         '--prompt=[Use custom prompt file]:prompt file:_files' \
         '--model=[Specify LLM model to use]:model:->models' \
-        '--lang[Generate content in specified language (default: English)]::'
+        '--lang[Generate content in specified language (default: English)]:language:'
 
     case "$state" in
         users)

--- a/completions/_aitag
+++ b/completions/_aitag
@@ -1,0 +1,25 @@
+#compdef aitag
+
+_aitag() {
+    local state
+    _arguments \
+        {-h,--help}'[Show help message]' \
+        {-a,--annotate}'[Create annotated tag]' \
+        {-s,--sign}'[Create signed tag]' \
+        {-u,--local-user=}'[Create tag with specific user]:user:->users' \
+        '--prompt=[Use custom prompt file]:prompt file:_files' \
+        '--model=[Specify LLM model to use]:model:->models'
+
+    case "$state" in
+        users)
+            user=$(gpg --list-secret-keys --keyid-format LONG | grep uid | awk -F'[<>]' '{print $2}')
+            _describe -t user 'user' user
+            ;;
+        models)
+            model=($(llm models | grep -v '^Default' | sed 's/^[^:]*: \([^(]*\)\( (.*)\)\?/\1/'))
+            _describe -t model 'model' model
+            ;;
+    esac
+}
+
+_aitag "$@"

--- a/completions/aitag.bash
+++ b/completions/aitag.bash
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+_aitag() {
+    local cur prev opts
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    opts="-h --help -a --annotate -s --sign -u --local-user --prompt --model"
+
+    if [[ "$cur" == -* ]]; then
+        COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
+        return 0
+    fi
+
+    case "$prev" in
+        -u|--local-user)
+            opts=$(gpg --list-secret-keys --keyid-format LONG | grep uid | awk -F'[<>]' '{print $2}')
+            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            return 0
+            ;;
+        --prompt)
+            compopt -o filenames
+            COMPREPLY=( $(compgen -f -- "${cur}") )
+            return 0
+            ;;
+        --model)
+            opts=$(llm models | grep -v '^Default' | sed 's/^[^:]*: \([^(]*\)\( (.*)\)\?/\1/')
+            ;;
+    esac
+
+    return 0
+}
+complete -F _aitag aitag

--- a/completions/aitag.bash
+++ b/completions/aitag.bash
@@ -4,23 +4,23 @@ _aitag() {
     local cur prev opts
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
-    prev="${COMP_WORDS[COMP_CWORD-1]}"
-    opts="-h --help -a --annotate -s --sign -u --local-user --prompt --model"
+    prev="${COMP_WORDS[COMP_CWORD - 1]}"
+    opts="-h --help -a --annotate -s --sign -u --local-user --prompt --model --lang"
 
     if [[ "$cur" == -* ]]; then
-        COMPREPLY=( $(compgen -W "$opts" -- "$cur") )
+        COMPREPLY=($(compgen -W "$opts" -- "$cur"))
         return 0
     fi
 
     case "$prev" in
-        -u|--local-user)
+        -u | --local-user)
             opts=$(gpg --list-secret-keys --keyid-format LONG | grep uid | awk -F'[<>]' '{print $2}')
-            COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+            COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
             return 0
             ;;
         --prompt)
             compopt -o filenames
-            COMPREPLY=( $(compgen -f -- "${cur}") )
+            COMPREPLY=($(compgen -f -- "${cur}"))
             return 0
             ;;
         --model)

--- a/completions/aitag.bash
+++ b/completions/aitag.bash
@@ -25,6 +25,7 @@ _aitag() {
             ;;
         --model)
             opts=$(llm models | grep -v '^Default' | sed 's/^[^:]*: \([^(]*\)\( (.*)\)\?/\1/')
+            COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
             ;;
     esac
 

--- a/completions/aitag.fish
+++ b/completions/aitag.fish
@@ -2,10 +2,6 @@ function _aitag_models
     llm models | grep -v '^Default' | sed 's/^[^:]*: \([^(]*\)\( (.*)\)\?/\1/'
 end
 
-function _aitag_user
-    gpg --list-secret-keys --keyid-format LONG | grep uid | awk '{print $3}' | sort | uniq
-end
-
 complete -c aitag -f
 complete -c aitag -s h -l help -d "Show help message"
 complete -c aitag -s a -l annotate -d "Create annotated tag"

--- a/completions/aitag.fish
+++ b/completions/aitag.fish
@@ -2,11 +2,15 @@ function _aitag_models
     llm models | grep -v '^Default' | sed 's/^[^:]*: \([^(]*\)\( (.*)\)\?/\1/'
 end
 
+function _aitag_user
+    gpg --list-secret-keys --keyid-format LONG | grep uid | awk -F'[<>]' '{print $2}'
+end
+
 complete -c aitag -f
 complete -c aitag -s h -l help -d "Show help message"
 complete -c aitag -s a -l annotate -d "Create annotated tag"
 complete -c aitag -s s -l sign -d "Create signed tag"
-complete -c aitag -s u -l local-user -d "Create tag with specific user" -x -a "(git config --get-regexp user.name | cut -d' ' -f2)"
+complete -c aitag -s u -l local-user -d "Create tag with specific user" -x -a "(_aitag_user)"
 complete -c aitag -l prompt -d "Use custom prompt file" -r -F
 complete -c aitag -l model -d "Specify LLM model to use" -x -a "(_aitag_models)"
 complete -c aitag -l lang -d "Generate content in specified language (default: English)"

--- a/completions/aitag.fish
+++ b/completions/aitag.fish
@@ -13,3 +13,4 @@ complete -c aitag -s s -l sign -d "Create signed tag"
 complete -c aitag -s u -l local-user -d "Create tag with specific user" -x -a "(git config --get-regexp user.name | cut -d' ' -f2)"
 complete -c aitag -l prompt -d "Use custom prompt file" -r -F
 complete -c aitag -l model -d "Specify LLM model to use" -x -a "(_aitag_models)"
+complete -c aitag -l lang -d "Generate content in specified language (default: English)"

--- a/completions/aitag.fish
+++ b/completions/aitag.fish
@@ -1,0 +1,15 @@
+function _aitag_models
+    llm models | grep -v '^Default' | sed 's/^[^:]*: \([^(]*\)\( (.*)\)\?/\1/'
+end
+
+function _aitag_user
+    gpg --list-secret-keys --keyid-format LONG | grep uid | awk '{print $3}' | sort | uniq
+end
+
+complete -c aitag -f
+complete -c aitag -s h -l help -d "Show help message"
+complete -c aitag -s a -l annotate -d "Create annotated tag"
+complete -c aitag -s s -l sign -d "Create signed tag"
+complete -c aitag -s u -l local-user -d "Create tag with specific user" -x -a "(git config --get-regexp user.name | cut -d' ' -f2)"
+complete -c aitag -l prompt -d "Use custom prompt file" -r -F
+complete -c aitag -l model -d "Specify LLM model to use" -x -a "(_aitag_models)"

--- a/prompts/aitag-prompt.txt
+++ b/prompts/aitag-prompt.txt
@@ -1,4 +1,4 @@
-Write short commit messages:
+Write a descriptive tag message:
 - The first line should be a short summary of the changes
     * Use the imperative mood. For example, "Fix", "Update", "Add" etc.
     * Ensure your text does not exceed 50 words
@@ -16,4 +16,4 @@ Summary of changes
 - changes
 - changes
 
-What you write will be passed directly to git tag -m "[message]"
+What you write will be passed directly to git tag -F "[file]"

--- a/prompts/aitag-prompt.txt
+++ b/prompts/aitag-prompt.txt
@@ -1,0 +1,19 @@
+Write short commit messages:
+- The first line should be a short summary of the changes
+    * Use the imperative mood. For example, "Fix", "Update", "Add" etc.
+    * Ensure your text does not exceed 50 words
+- A blank line after the summary line
+- Explain the 'why' behind changes
+- Use bullet points for multiple changes
+- If there are no changes, or the input is blank - then return a blank string
+
+Think carefully before you write your commit message.
+
+The output format should be:
+
+Summary of changes
+
+- changes
+- changes
+
+What you write will be passed directly to git tag -m "[message]"


### PR DESCRIPTION
### feat: Add `aitag` for AI-Generated Tag Messages

This pull request introduces a new script, `aitag`, designed to automate the creation of git tag messages using a Large Language Model (LLM). Manually summarizing all the changes since the last release for an annotated tag can be a tedious process. This tool streamlines the release workflow by generating a descriptive summary of the changes between the last tag and the current commit.

The `aitag` script functions similarly to `aicommit` but is specifically tailored for tagging. It determines the diff since the most recent tag, sends it to an LLM via the `llm` tool, and generates a draft message. The user can then review and edit this message in their default editor before confirming the tag creation.

Close #3

Here is a summary of the changes:

* **New `aitag` script**: A command-line tool that generates a message for a new git tag by summarizing the changes since the last tag.
* **Interactive Workflow**: Opens the AI-generated message in the user's `$EDITOR` for review and modification before creating the tag.
* **Feature Support**: Passes through common `git tag` options, including creating annotated (`-a`), signed (`-s`), and user-specific (`-u`) tags.
* **Customization**: Allows users to specify the LLM model (`--model`), a custom prompt file (`--prompt`), and the output language (`--lang`).
* **Shell Completions**: Adds command-line completions for Bash, Zsh, and Fish to improve usability and discoverability of options.
* **Default Prompt**: Includes a new prompt file (`prompts/aitag-prompt.txt`) specifically crafted for generating clear and concise tag annotations.
