### PR TITLE
Prepend generated message to preserve existing user content in the commit message file.

### DIFF
--- a/ai-commit-msg
+++ b/ai-commit-msg
@@ -139,4 +139,11 @@ kill_spin
 # echo
 
 # Write the generated commit message to the specified file (usually the commit message file in .git)
-echo "$commit_msg" >"$1"
+TMP_FILE=$(mktemp)
+if [ -z "$TMP_FILE" ]; then
+    exit 1
+fi
+trap "rm -f $TMP_FILE" EXIT
+echo "$commit_msg" >"$TMP_FILE"
+cat "$1" >>"$TMP_FILE"
+mv "$TMP_FILE" "$1"


### PR DESCRIPTION
### Feat: Prepend generated message to preserve Git comments

This change improves the user experience when using the script as a `prepare-commit-msg` hook.

Previously, the script would overwrite the entire commit message file provided by Git. This had the unintended side effect of deleting all the helpful, commented-out context that Git adds, such as the list of changed files and the current branch.

This update modifies the behavior to prepend the AI-generated message to the existing content of the commit file. This way, the user sees the generated message at the top of their editor, followed by the standard Git status information, allowing for a better final review before committing.

Close #9

Changes in this pull request:

* Refactored the file-writing logic to prepend the generated message instead of overwriting the commit file.
* Introduced `mktemp` to safely create a temporary file for staging the new content.
* Added a `trap` to ensure the temporary file is reliably cleaned up when the script exits.
* Preserved the original content of the commit message file, including Git's comments.
