### PR TITLE
Standardize the language environment variable to `GITAI_LANG` for consistency across all tools and documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ You can specify a custom prompt file using the `--prompt` flag for `aitag`, and 
 ## Environment Variables
 
 * `GITAI_MODEL`: Set the default LLM model to use.
-* `GITAI_LANGUAGE`: Set the default language for generation.
+* `GITAI_LANG`: Set the default language for generation.
 * `GITAI_COMMIT_MSG_PROMPT`: Override the default commit message prompt file path.
 * `GITAI_PR_PROMPT_TITLE`: Override the default PR title prompt file path.
 * `GITAI_PR_PROMPT_BODY`: Override the default PR body prompt file path.

--- a/ai-commit-msg
+++ b/ai-commit-msg
@@ -29,7 +29,7 @@ Environment Variables:
   GITAI_SKIP_AI_COMMIT_MSG_HOOK  If set to a non-empty value, the script will exit without generating a message.
   GITAI_MODEL                    Specifies the LLM model to use (e.g., 'gpt-4o'). Defaults to the model set as default in the 'llm' tool.
   GITAI_COMMIT_MSG_PROMPT        Path to a custom prompt file. Defaults to '$DEFAULT_PROMPT_FILE'.
-  GITAI_LANGUAGE                 The language for the generated commit message. Defaults to 'English'.
+  GITAI_LANG                     The language for the generated commit message. Defaults to 'English'.
 EOF
 }
 
@@ -116,7 +116,7 @@ fi
 export LLM_MODEL="$MODEL"
 
 PROMPT_FILE=${GITAI_COMMIT_MSG_PROMPT:-$DEFAULT_PROMPT_FILE}
-LANGUAGE=${GITAI_LANGUAGE:-English}
+LANGUAGE=${GITAI_LANG:-English}
 
 if [ ! -f "$PROMPT_FILE" ]; then
     echo -e "${RED}Error: Prompt file not found: $PROMPT_FILE${NC}" >&2

--- a/aipr
+++ b/aipr
@@ -236,7 +236,7 @@ show_help() {
     echo "  GITAI_PR_PROMPT_TITLE       Override default PR title prompt file path"
     echo "  GITAI_PR_PROMPT_BODY        Override default PR body prompt file path"
     echo "  GITAI_MODEL                 Set default LLM model for PR generation"
-    echo "  GITAI_LANG                  Set default language for generation"
+    echo "  GITAI_LANG                  The language for the generated commit message. Defaults to 'English'."
     echo ""
     echo "GH FLAGS"
     echo "  All flags provided by 'gh pr create/edit' can be pass to the aipr command."
@@ -427,7 +427,7 @@ PROMPT_TITLE=${GITAI_PR_PROMPT_TITLE:-$DEFAULT_TITLE_PROMPT}
 PROMPT_BODY=${GITAI_PR_PROMPT_BODY:-$DEFAULT_BODY_PROMPT}
 MODEL=${GITAI_MODEL}
 UPDATE_TITLE=
-LANGUAGE=${GITAI_LANGUAGE:-English}
+LANGUAGE=${GITAI_LANG:-English}
 
 # Parse command line arguments manually
 # GH_ARGS=()

--- a/aitag
+++ b/aitag
@@ -79,7 +79,7 @@ show_help() {
     echo "ENVIRONMENT VARIABLES:"
     echo "  GITAI_TAG_PROMPT       Default prompt file path (default: $DEFAULT_PROMPT_FILE)"
     echo "  GITAI_MODEL            Set default LLM model for PR generation"
-    echo "  GITAI_LANG             Set default language for generation"
+    echo "  GITAI_LANG             The language for the generated commit message. Defaults to 'English'."
     echo
     echo "EXAMPLES:"
     echo "  aitag v1.0.0                    # Tag HEAD commit as v1.0.0"
@@ -107,7 +107,7 @@ init_config
 TAG_OPTS=()
 PROMPT_FILE=${GITAI_TAG_PROMPT:-$DEFAULT_PROMPT_FILE}
 MODEL=${GITAI_MODEL}
-LANGUAGE=${GITAI_LANGUAGE:-English}
+LANGUAGE=${GITAI_LANG:-English}
 
 while [[ $# -gt 0 ]]; do
     case "$1" in


### PR DESCRIPTION
Refactor: Rename `GITAI_LANGUAGE` to `GITAI_LANG` for Consistency

This pull request renames the `GITAI_LANGUAGE` environment variable to `GITAI_LANG` across the codebase. The primary motivation is to enhance consistency, brevity, and clarity within the project's environment variable naming conventions.

The shorter `GITAI_LANG` aligns better with other variables like `GITAI_MODEL` and is a more common abbreviation in similar contexts. Additionally, the description for this variable has been standardized across all scripts to provide a clearer explanation of its purpose and default value.

Close #13

**Changes:**

* Renamed the `GITAI_LANGUAGE` environment variable to `GITAI_LANG`.
* Updated `README.md` to reflect the new `GITAI_LANG` environment variable.
* Modified `ai-commit-msg` script to use `GITAI_LANG` for language setting and updated its help/description.
* Modified `aipr` script to use `GITAI_LANG` for language setting and updated its help/description for clarity.
* Modified `aitag` script to use `GITAI_LANG` for language setting and updated its help/description for clarity.
