### PR TITLE
Clarify `GITAI_LANG` variable description in help messages to accurately reflect its impact on generated pull request and tag messages.

### DIFF
--- a/aipr
+++ b/aipr
@@ -236,7 +236,7 @@ show_help() {
     echo "  GITAI_PR_PROMPT_TITLE       Override default PR title prompt file path"
     echo "  GITAI_PR_PROMPT_BODY        Override default PR body prompt file path"
     echo "  GITAI_MODEL                 Set default LLM model for PR generation"
-    echo "  GITAI_LANG                  The language for the generated commit message. Defaults to 'English'."
+    echo "  GITAI_LANG                  The language for the generated pull request message. Defaults to 'English'."
     echo ""
     echo "GH FLAGS"
     echo "  All flags provided by 'gh pr create/edit' can be pass to the aipr command."

--- a/aitag
+++ b/aitag
@@ -79,7 +79,7 @@ show_help() {
     echo "ENVIRONMENT VARIABLES:"
     echo "  GITAI_TAG_PROMPT       Default prompt file path (default: $DEFAULT_PROMPT_FILE)"
     echo "  GITAI_MODEL            Set default LLM model for PR generation"
-    echo "  GITAI_LANG             The language for the generated commit message. Defaults to 'English'."
+    echo "  GITAI_LANG             The language for the generated tag message. Defaults to 'English'."
     echo
     echo "EXAMPLES:"
     echo "  aitag v1.0.0                    # Tag HEAD commit as v1.0.0"


### PR DESCRIPTION
Refactor: Clarify GITAI_LANG variable description for aipr and aitag

This pull request addresses a minor inaccuracy in the help output for the `aipr` and `aitag` commands. The description for the `GITAI_LANG` environment variable previously stated it controls the language for "generated commit message," which is not entirely accurate for these specific tools.

The `aipr` command generates a pull request message, and `aitag` generates a tag message. This change updates the help text to correctly reflect what type of message `GITAI_LANG` influences for each command, improving clarity for users.

ref: #13

### Changes

* Updated the description for `GITAI_LANG` in the `aipr` help output from "generated commit message" to "generated pull request message."
* Updated the description for `GITAI_LANG` in the `aitag` help output from "generated commit message" to "generated tag message."
