### PR TITLE
Ensure script operates from repository root for consistent Git operations.

### DIFF
--- a/aipr
+++ b/aipr
@@ -512,9 +512,8 @@ if ! is_git_repo; then
 fi
 
 repo_root=$(git rev-parse --show-toplevel)
-pwd=$(pwd)
-
-trap 'cd $pwd' EXIT
+original_dir="$PWD"
+trap 'cd "$original_dir"' EXIT
 
 cd "$repo_root" || exit 1
 

--- a/aipr
+++ b/aipr
@@ -511,6 +511,13 @@ if ! is_git_repo; then
     exit 1
 fi
 
+repo_root=$(git rev-parse --show-toplevel)
+pwd=$(pwd)
+
+trap 'cd $pwd' EXIT
+
+cd "$repo_root" || exit 1
+
 if ! git ls-remote --exit-code "$BASE_REMOTE" &>/dev/null; then
     BASE_REMOTE=$(select_remote)
 fi


### PR DESCRIPTION
## Refactor: Ensure consistent Git operations from repository root

This pull request introduces changes to ensure that all Git operations performed by the `aipr` script consistently run from the root directory of the Git repository.

Previously, the script implicitly relied on the current working directory when executing Git commands. If the script was invoked from a subdirectory within a repository, certain Git commands might have behaved unexpectedly or failed due to incorrect paths or contexts. By explicitly navigating to the repository root, we eliminate these potential inconsistencies and ensure reliable execution regardless of where the script is called from within the repository.

Additionally, a `trap` mechanism has been added to automatically return the user to their original working directory upon script exit, preserving their shell context and preventing unintended side effects.

close #17 

### Changes:

*   Determined the Git repository's root directory using `git rev-parse --show-toplevel`.
*   Stored the original working directory (`pwd`) at the start of the script.
*   Implemented an `EXIT` trap to automatically change back to the original working directory when the script finishes.
*   Changed the current working directory to the Git repository's root directory before executing further script logic.
