### PR TITLE
Fix: Redirect remote selection output to stderr to avoid interfering with script execution

### DIFF
--- a/aipr
+++ b/aipr
@@ -104,9 +104,9 @@ select_remote() {
         return 0
     fi
 
-    echo "Available remotes:"
+    echo "Available remotes:" >&2
     for i in "${!remotes[@]}"; do
-        printf "%d) %s\n" $((i + 1)) "${remotes[$i]}"
+        printf "%d) %s\n" $((i + 1)) "${remotes[$i]}" >&2
     done
 
     while true; do


### PR DESCRIPTION
This pull request addresses an issue where the output of the `select_remote` function was not being directed to standard error, potentially interfering with scripts that rely on standard output for their own operations.

The following changes have been made:

* Redirected the "Available remotes:" header to standard error (`>&2`).
* Redirected the formatted list of remotes to standard error (`>&2`).

This ensures that the user-facing information from `select_remote` is presented on the terminal without polluting the standard output stream.

close #16
