### PR TITLE
Add upstream tracking to git push for improved branch management

### DIFF
--- a/aipr
+++ b/aipr
@@ -149,7 +149,7 @@ prompt_push() {
     case "$choice" in
         y | Y)
             echo "Pushing to $remote/$branch..."
-            if git push "$remote" "$branch"; then
+            if git push -u "$remote" "$branch"; then
                 echo -e "${GREEN}Successfully pushed to $remote/$branch${NC}"
                 return 0
             else


### PR DESCRIPTION
This PR introduces a small but significant improvement to the `aipr` script by making the `git push` command use the `-u` flag.

The `-u` flag (or `--set-upstream`) is used to set the upstream branch for the current local branch. This means that future `git pull` and `git push` commands from this branch will automatically know which remote branch to interact with, simplifying subsequent operations.

Changes include:

* Modified the `git push` command within the `prompt_push` function to include the `-u` flag.

This change addresses the need for more robust and user-friendly Git operations within the script.

close #21
