### PR TITLE
feat: support multiple AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # gitai
 
-`gitai` is a set of command-line tools that use the pi coding agent in command-line mode to help with your Git workflow. It can help you write commit messages, create pull requests, and generate tags.
+`gitai` is a set of command-line tools that use a locally installed AI coding agent to help with your Git workflow. It can help you write commit messages, create pull requests, and generate tags.
 
 ## Requirements
 
-Install and configure `pi` with the provider and model you want to use. `gitai` invokes pi in non-interactive, ephemeral, tool-free mode, so generation cannot modify your working tree and does not leave behind a pi session.
+Install and configure at least one supported agent: [pi](https://github.com/badlogic/pi-mono), [Oh My Pi](https://github.com/can1357/oh-my-pi), [Codex CLI](https://github.com/openai/codex), or [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview). `gitai` invokes the selected agent non-interactively without write-capable tools and without persisting a session.
+
+Set `GITAI_AGENT` to choose an agent explicitly. Accepted values are `pi`, `oh-my-pi` (or `omp`), `codex`, and `claude-code` (or `claude`). When it is unset, `gitai` uses the first available agent in this order: pi, Oh My Pi, Codex, Claude Code. It exits with an error if none is available.
 
 ## Installation
 
@@ -60,7 +62,7 @@ Now, whenever you run `git commit`, the hook will automatically generate a commi
 
 ### `aipr`
 
-`aipr` is a command-line tool that uses AI to generate a pull request for you. It generates the title and body together in one pi interaction based on the changes in your current branch.
+`aipr` is a command-line tool that uses AI to generate a pull request for you. It generates the title and body together in one agent interaction based on the changes in your current branch.
 
 #### Usage
 
@@ -76,7 +78,7 @@ aipr [options]
 * `-T, --template <file>`: Specify a PR template file to use.
 * `--prompt-title <file>`: Path to PR title prompt template (default: `$HOME/.config/gitai/prompts/aipr-title-prompt.txt`).
 * `--prompt-body <file>`: Path to PR body prompt template (default: `$HOME/.config/gitai/prompts/aipr-body-prompt.txt`).
-* `--model <model>`: pi model or model pattern to use, such as `openai/gpt-4o`.
+* `--model <model>`: Model to use with the selected agent.
 * `--update-title`: Update PR title when editing existing PR.
 * `--lang <lang>`: Generate content in specified language (default: `English`).
 * `-h, --help`: Show this help message.
@@ -99,7 +101,7 @@ aitag [OPTIONS] TAG_NAME [COMMIT]
 * `-s, --sign`: Create a signed tag.
 * `-u, --local-user USER`: Create tag with specific user.
 * `--prompt FILE`: Use custom prompt file (default: `$HOME/.config/gitai/prompts/aitag-prompt.txt`)..
-* `--model <model>`: pi model or model pattern to use, such as `openai/gpt-4o`.
+* `--model <model>`: Model to use with the selected agent.
 * `--lang <lang>`: Generate content in specified language (default: `English`).
 * `-h, --help`: Show this help message.
 
@@ -111,7 +113,8 @@ You can specify a custom prompt file using the `--prompt` flag for `aitag`, and 
 
 ## Environment Variables
 
-* `GITAI_MODEL`: Set the pi model or model pattern to use. When unset, pi's configured default is used.
+* `GITAI_AGENT`: Select `pi`, `oh-my-pi`, `codex`, or `claude-code`. Common executable-name aliases `omp` and `claude` are also accepted. When unset, agents are auto-detected in that order.
+* `GITAI_MODEL`: Set the model to use. When unset, the selected agent's configured default is used.
 * `GITAI_LANG`: Set the default language for generation.
 * `GITAI_COMMIT_MSG_PROMPT`: Override the default commit message prompt file path.
 * `GITAI_PR_PROMPT_TITLE`: Override the default PR title prompt file path.
@@ -121,7 +124,23 @@ You can specify a custom prompt file using the `--prompt` flag for `aitag`, and 
 
 ## Testing
 
-Run the shell integration suite with `tests/run.sh`. The tests use temporary Git repositories and a stubbed pi command, so they do not make AI requests.
+Run the shell integration suite with `tests/run.sh`. The tests use temporary Git repositories and stubbed agent commands, so they do not make AI requests.
+
+To run the real GitHub end-to-end suite, first configure all four supported agents. Claude Code must be signed in (`claude auth login`), and `gh` must have permission to create and delete private repositories. Classic OAuth tokens need the `delete_repo` scope, which can be added with `gh auth refresh -h github.com -s delete_repo`. Then run:
+
+```bash
+tests/integration-github.sh
+```
+
+The suite creates one temporary private GitHub repository. For each of pi, Oh My Pi, Codex, and Claude Code, it creates a branch, generates and verifies a commit message with `ai-commit-msg`, creates and verifies an annotated tag with `aitag`, creates a pull request with `aipr`, and verifies the remote branch, tag, PR title, PR body, state, and base/head branches. The local temporary directory and GitHub repository are deleted on success or failure.
+
+Use `--keep-repo` to retain the GitHub repository for manual verification:
+
+```bash
+tests/integration-github.sh --keep-repo
+```
+
+The retained repository and PR URLs are printed before the script exits. If automatic deletion fails, the script exits unsuccessfully and prints the exact `gh repo delete` command needed for cleanup.
 
 To manually test this checkout in place of a Homebrew installation, run:
 
@@ -129,7 +148,7 @@ To manually test this checkout in place of a Homebrew installation, run:
 scripts/brew-dev-link link
 ```
 
-This runs `brew unlink gitai` and links `aipr`, `aitag`, and `ai-commit-msg` from the current checkout into Homebrew's `bin` directory. Restore the installed Homebrew version after testing with:
+This runs `brew unlink gitai` and links `aipr`, `aitag`, `ai-commit-msg`, the internal `gitai-agent` runner, and the shared `gitai-common.sh` runtime from the current checkout into Homebrew's `bin` directory. Restore the installed Homebrew version after testing with:
 
 ```bash
 scripts/brew-dev-link restore

--- a/ai-commit-msg
+++ b/ai-commit-msg
@@ -5,10 +5,32 @@ if [ -n "$GITAI_SKIP_AI_COMMIT_MSG_HOOK" ]; then
     exit 0
 fi
 
-# ANSI color codes for styling the output
-RED='\033[0;31m'    # Sets text to red
-YELLOW='\033[0;33m' # Sets text to yellow
-NC='\033[0m'        # Resets the text color to default, no color
+GITAI_SCRIPT_PATH=${BASH_SOURCE[0]}
+while [ -L "$GITAI_SCRIPT_PATH" ]; do
+    GITAI_SCRIPT_DIR=$(cd -- "$(dirname -- "$GITAI_SCRIPT_PATH")" && pwd)
+    GITAI_SCRIPT_PATH=$(readlink "$GITAI_SCRIPT_PATH")
+    case "$GITAI_SCRIPT_PATH" in
+        /*) ;;
+        *) GITAI_SCRIPT_PATH="$GITAI_SCRIPT_DIR/$GITAI_SCRIPT_PATH" ;;
+    esac
+done
+GITAI_SCRIPT_DIR=$(cd -- "$(dirname -- "$GITAI_SCRIPT_PATH")" && pwd)
+GITAI_COMMON_SCRIPT="$GITAI_SCRIPT_DIR/gitai-common.sh"
+if [ ! -r "$GITAI_COMMON_SCRIPT" ]; then
+    echo "Error: gitai-common.sh is not installed next to ai-commit-msg." >&2
+    exit 1
+fi
+. "$GITAI_COMMON_SCRIPT"
+
+TEMP_FILES=()
+
+cleanup_temp_files() {
+    if [ "${#TEMP_FILES[@]}" -gt 0 ]; then
+        rm -f -- "${TEMP_FILES[@]}"
+    fi
+}
+
+trap cleanup_temp_files EXIT
 
 DEFAULT_PROMPT_FILE=$HOME/.config/gitai/prompts/ai-commit-msg-prompt.txt
 
@@ -17,7 +39,7 @@ show_help() {
     cat <<EOF
 Usage: $(basename "$0") [options]
 
-Automatically generates a commit message for staged changes using pi.
+Automatically generates a commit message for staged changes using an AI agent.
 This script is typically used as a 'prepare-commit-msg' Git hook.
 
 Options:
@@ -25,50 +47,11 @@ Options:
 
 Environment Variables:
   GITAI_SKIP_AI_COMMIT_MSG_HOOK  If set to a non-empty value, the script will exit without generating a message.
-  GITAI_MODEL                    Specifies the pi model or model pattern to use (e.g., 'openai/gpt-4o'). Defaults to pi's configured model.
+  GITAI_AGENT                    AI agent to use: pi, oh-my-pi, codex, or claude-code. Auto-detected when unset.
+  GITAI_MODEL                    Specifies the model to use. Defaults to the selected agent's configured model.
   GITAI_COMMIT_MSG_PROMPT        Path to a custom prompt file. Defaults to '$DEFAULT_PROMPT_FILE'.
   GITAI_LANG                     The language for the generated commit message. Defaults to 'English'.
 EOF
-}
-
-# Function to display a spinning animation during AI processing
-spin_animation() {
-    local msg="$1"
-    # Only show animation if output is going to a terminal
-    if ! [ -t 1 ]; then
-        echo "$1..." # Just show the message without animation
-        return
-    fi
-
-    # Array of spinner characters for the animation
-    local spinner=("⠋" "⠙" "⠹" "⠸" "⠼" "⠴" "⠦" "⠧" "⠇" "⠏")
-    # Infinite loop to keep the animation running
-    while true; do
-        for i in "${spinner[@]}"; do
-            tput civis                                    # Hide the cursor to enhance the animation appearance
-            tput el1                                      # Clear the line from the cursor to the beginning to display the spinner
-            printf "\r${YELLOW}%s${NC} %s..." "$i" "$msg" # Print the spinner and message
-            sleep 0.1                                     # Delay to control the speed of the animation
-            tput cub $((${#msg} + 5))                     # Move the cursor back to reset the spinner position
-        done
-    done
-}
-
-kill_spin() {
-    if [ -n "$SPIN_PID" ]; then
-        kill "$SPIN_PID" 2>/dev/null || true
-        wait "$SPIN_PID" 2>/dev/null || true # Wait for the process to terminate and suppress error messages
-        SPIN_PID=
-        printf "\n"
-    fi
-}
-
-# Function to handle interrupts
-cleanup() {
-    echo -e "\n${RED}Script interrupted. Cleaning up...${NC}"
-    kill_spin
-    tput cnorm # Show the cursor
-    exit 1
 }
 
 init_config() {
@@ -87,7 +70,7 @@ init_config() {
 
 init_config
 
-trap cleanup SIGINT
+trap gitai_handle_interrupt SIGINT
 
 # Parse command-line arguments for help flag
 if [[ "$1" == "-h" || "$1" == "--help" ]]; then
@@ -100,9 +83,10 @@ if [ -n "$2" ]; then
     exit 0 # Exit script if it's a merge commit, no custom message needed
 fi
 
-# Check if the `pi` command is installed
-if ! command -v pi &>/dev/null; then
-    echo -e "${RED}Error: 'pi' command is not installed. Please install it and try again.${NC}"
+if ! gitai_init_agent_runner "$GITAI_SCRIPT_DIR" ai-commit-msg; then
+    exit 1
+fi
+if ! gitai_check_agent_runner; then
     exit 1
 fi
 
@@ -130,29 +114,48 @@ if [ -z "$diff" ]; then
 fi
 
 # Start the spinning animation in the background
-MODEL_DISPLAY=${MODEL:-pi default}
-spin_animation "Generating commit message using $MODEL_DISPLAY" &
+MODEL_DISPLAY=${MODEL:-${GITAI_AGENT:-auto-selected agent default}}
+AGENT_ERROR_FILE=$(mktemp)
+if [ -z "$AGENT_ERROR_FILE" ]; then
+    echo "Error: Failed to create a temporary agent error file." >&2
+    exit 1
+fi
+TEMP_FILES+=("$AGENT_ERROR_FILE")
+gitai_spin_animation "Generating commit message using $MODEL_DISPLAY" &
+# Read by gitai_kill_spin from the sourced common runtime.
+# shellcheck disable=SC2034
 SPIN_PID=$!
 
-PI_ARGS=(--print --no-session --no-tools --no-context-files --system-prompt "$PROMPT")
-if [ -n "$MODEL" ]; then
-    PI_ARGS+=(--model "$MODEL")
-fi
-
-if ! commit_msg=$(printf '%s\n' "$diff" | pi "${PI_ARGS[@]}" 2>&1); then
+if ! commit_msg=$(printf '%s\n' "$diff" | "$AGENT_RUNNER" "$PROMPT" "$MODEL" 2>"$AGENT_ERROR_FILE"); then
     # Stop the spinning animation by killing its process
-    kill_spin
+    gitai_kill_spin
 
     # Finalizing output
     tput cnorm  # Show the cursor again
     printf "\n" # Move the cursor to the next line
 
-    printf "${RED}Error: 'pi' command failed to generate the commit message:\n%s${NC}\n\nManually set the commit message" "$commit_msg"
+    agent_error=$(cat "$AGENT_ERROR_FILE")
+    agent_diagnostic=$commit_msg
+    if [ -n "$agent_error" ]; then
+        if [ -n "$agent_diagnostic" ]; then
+            agent_diagnostic="$agent_diagnostic
+$agent_error"
+        else
+            agent_diagnostic=$agent_error
+        fi
+    fi
+    if [ -z "$agent_diagnostic" ]; then
+        agent_diagnostic="Agent exited unsuccessfully without diagnostic output."
+    fi
+    printf "${RED}Error: AI agent failed to generate the commit message:\n%s${NC}\n\nManually set the commit message" "$agent_diagnostic"
     exit 1
 fi
 
 # Stop the spinning animation by killing its process
-kill_spin
+gitai_kill_spin
+if [ -s "$AGENT_ERROR_FILE" ]; then
+    cat "$AGENT_ERROR_FILE" >&2
+fi
 
 # Display the generated commit message with color-coded headings
 # echo -e "${BLUE}=== Generated Commit Message ===${NC}"
@@ -165,7 +168,7 @@ TMP_FILE=$(mktemp)
 if [ -z "$TMP_FILE" ]; then
     exit 1
 fi
-trap 'rm -f -- "$TMP_FILE"' EXIT
+TEMP_FILES+=("$TMP_FILE")
 
 if ! {
     echo "$commit_msg"

--- a/aipr
+++ b/aipr
@@ -1,60 +1,28 @@
 #!/usr/bin/env bash
 # Thanks Harper Reed https://harper.blog/2024/03/11/use-an-llm-to-automagically-generate-meaningful-git-commit-messages/
 
-# ANSI color codes for styling the output
-RED='\033[0;31m'    # Sets text to red
-GREEN='\033[0;32m'  # Sets text to green
-YELLOW='\033[0;33m' # Sets text to yellow
-BLUE='\033[0;34m'   # Sets text to blue
-NC='\033[0m'        # Resets the text color to default, no color
+GITAI_SCRIPT_PATH=${BASH_SOURCE[0]}
+while [ -L "$GITAI_SCRIPT_PATH" ]; do
+    GITAI_SCRIPT_DIR=$(cd -- "$(dirname -- "$GITAI_SCRIPT_PATH")" && pwd)
+    GITAI_SCRIPT_PATH=$(readlink "$GITAI_SCRIPT_PATH")
+    case "$GITAI_SCRIPT_PATH" in
+        /*) ;;
+        *) GITAI_SCRIPT_PATH="$GITAI_SCRIPT_DIR/$GITAI_SCRIPT_PATH" ;;
+    esac
+done
+GITAI_SCRIPT_DIR=$(cd -- "$(dirname -- "$GITAI_SCRIPT_PATH")" && pwd)
+GITAI_COMMON_SCRIPT="$GITAI_SCRIPT_DIR/gitai-common.sh"
+if [ ! -r "$GITAI_COMMON_SCRIPT" ]; then
+    echo "Error: gitai-common.sh is not installed next to aipr." >&2
+    exit 1
+fi
+. "$GITAI_COMMON_SCRIPT"
 
 DEFAULT_TITLE_PROMPT=$HOME/.config/gitai/prompts/aipr-title-prompt.txt
 DEFAULT_BODY_PROMPT=$HOME/.config/gitai/prompts/aipr-body-prompt.txt
 
-SPIN_PID=
-
 TEMP_FILES=()
 trap 'rm -f "${TEMP_FILES[@]}"' EXIT SIGINT TERM
-
-# Function to display a spinning animation during AI processing
-spin_animation() {
-    local msg="$1"
-    # Only show animation if output is going to a terminal
-    if ! [ -t 1 ]; then
-        echo "$1..." # Just show the message without animation
-        return
-    fi
-
-    # Array of spinner characters for the animation
-    local spinner=("⠋" "⠙" "⠹" "⠸" "⠼" "⠴" "⠦" "⠧" "⠇" "⠏")
-    # Infinite loop to keep the animation running
-    while true; do
-        for i in "${spinner[@]}"; do
-            tput civis                                    # Hide the cursor to enhance the animation appearance
-            tput el1                                      # Clear the line from the cursor to the beginning to display the spinner
-            printf "\r${YELLOW}%s${NC} %s..." "$i" "$msg" # Print the spinner and message
-            sleep 0.1                                     # Delay to control the speed of the animation
-            tput cub $((${#msg} + 5))                     # Move the cursor back to reset the spinner position
-        done
-    done
-}
-
-kill_spin() {
-    if [ -n "$SPIN_PID" ]; then
-        kill "$SPIN_PID" 2>/dev/null || true
-        wait "$SPIN_PID" 2>/dev/null || true # Wait for the process to terminate and suppress error messages
-        SPIN_PID=
-        printf "\n"
-    fi
-}
-
-# Function to handle interrupts
-cleanup() {
-    echo -e "\n${RED}Script interrupted. Cleaning up...${NC}"
-    kill_spin
-    tput cnorm # Show the cursor
-    exit 1
-}
 
 # A helper to create a temp file and exit on failure
 create_temp_file() {
@@ -164,10 +132,6 @@ prompt_push() {
     esac
 }
 
-is_git_repo() {
-    git rev-parse --is-inside-work-tree >/dev/null 2>&1
-}
-
 remote_2_url() {
     git remote get-url "$1"
 }
@@ -227,7 +191,7 @@ show_help() {
     echo "  -T, --template <file>     Specify a PR template file to use"
     echo "  --prompt-title <file>     Path to PR title prompt template (default: $DEFAULT_TITLE_PROMPT)"
     echo "  --prompt-body <file>      Path to PR body prompt template (default: $DEFAULT_BODY_PROMPT)"
-    echo "  --model <model>           pi model or model pattern to use"
+    echo "  --model <model>           Model to use with the selected AI agent"
     echo "  --update-title            Update PR title when editing existing PR"
     echo "  --lang <lang>             Generate content in specified language (default: English)"
     echo "  -h, --help                Show this help message"
@@ -235,7 +199,8 @@ show_help() {
     echo "ENVIRONMENT VARIABLES:"
     echo "  GITAI_PR_PROMPT_TITLE       Override default PR title prompt file path"
     echo "  GITAI_PR_PROMPT_BODY        Override default PR body prompt file path"
-    echo "  GITAI_MODEL                 Set the pi model or model pattern for PR generation"
+    echo "  GITAI_AGENT                 AI agent: pi, oh-my-pi, codex, or claude-code (auto-detected when unset)"
+    echo "  GITAI_MODEL                 Set the model for PR generation"
     echo "  GITAI_LANG                  The language for the generated pull request message. Defaults to 'English'."
     echo ""
     echo "GH FLAGS"
@@ -266,17 +231,6 @@ init_config() {
         mkdir -p "$dir"
         cp "$brew_body_prompt" "$DEFAULT_BODY_PROMPT"
     fi
-}
-
-check_required_commands() {
-    local missing=0
-    for cmd in git gh jq pi; do
-        if ! command -v "$cmd" >/dev/null 2>&1; then
-            echo "Error: $cmd is not installed"
-            missing=$((missing + 1))
-        fi
-    done
-    return $missing
 }
 
 ongoing_pr() {
@@ -315,30 +269,34 @@ $output_format
 EOF
     )
 
-    local model_display=${MODEL:-pi default}
-    spin_animation "Generating PR content using $model_display" &
+    local model_display=${MODEL:-${GITAI_AGENT:-auto-selected agent default}}
+    gitai_spin_animation "Generating PR content using $model_display" &
+    # Read by gitai_kill_spin from the sourced common runtime.
+    # shellcheck disable=SC2034
     SPIN_PID=$!
 
-    local pi_args=(--print --no-session --no-tools --no-context-files --system-prompt "$prompt")
-    if [ -n "$MODEL" ]; then
-        pi_args+=(--model "$MODEL")
-    fi
-
-    local response
-    if ! response=$(printf '%s\n' "$diff" | pi "${pi_args[@]}"); then
-        kill_spin
-        echo -e "${RED}Error: 'pi' command failed to generate PR content.${NC}" >&2
+    local response normalized_response
+    if ! response=$(printf '%s\n' "$diff" | "$AGENT_RUNNER" "$prompt" "$MODEL"); then
+        gitai_kill_spin
+        echo -e "${RED}Error: AI agent failed to generate PR content.${NC}" >&2
         exit 1
     fi
-    kill_spin
+    gitai_kill_spin
+
+    if ! normalized_response=$(printf '%s\n' "$response" | gitai_extract_json_object); then
+        echo -e "${RED}Error: AI agent returned invalid PR content; expected a JSON object.${NC}" >&2
+        printf 'Raw agent response:\n%s\n' "$response" >&2
+        exit 1
+    fi
+    response=$normalized_response
 
     if ! printf '%s\n' "$response" | jq -e 'type == "object" and (.body | type == "string")' >/dev/null; then
-        echo -e "${RED}Error: pi returned invalid PR content; expected a JSON object with a body string.${NC}" >&2
+        echo -e "${RED}Error: AI agent returned invalid PR content; expected a JSON object with a body string.${NC}" >&2
         exit 1
     fi
     if [ "$include_title" = 1 ]; then
         if ! printf '%s\n' "$response" | jq -e '(.title | type == "string") and (.title | length > 0)' >/dev/null; then
-            echo -e "${RED}Error: pi returned invalid PR content; expected a non-empty title string.${NC}" >&2
+            echo -e "${RED}Error: AI agent returned invalid PR content; expected a non-empty title string.${NC}" >&2
             exit 1
         fi
         printf '%s\n' "$response" | jq -r '.title' >"$title_file"
@@ -483,6 +441,10 @@ EOF
 
 init_config
 
+if ! gitai_init_agent_runner "$GITAI_SCRIPT_DIR" aipr; then
+    exit 1
+fi
+
 BASE_REMOTE=origin
 BASE_BRANCH=
 HEAD_BRANCH=$(get_current_branch)
@@ -558,14 +520,17 @@ if [ ! -f "$PROMPT_BODY" ]; then
     exit 1
 fi
 
-trap cleanup SIGINT
+trap gitai_handle_interrupt SIGINT
 
-if ! check_required_commands; then
+if ! gitai_check_required_commands git gh jq; then
     echo "Please install missing commands before proceeding" >&2
     exit 1
 fi
+if ! gitai_check_agent_runner; then
+    exit 1
+fi
 
-if ! is_git_repo; then
+if ! gitai_is_git_repo; then
     echo "Not in a Git repository" >&2
     exit 1
 fi
@@ -582,14 +547,16 @@ fi
 
 HEAD_REMOTE=$(get_branch_remote "$HEAD_BRANCH")
 
-spin_animation "Fetching new commits" &
+gitai_spin_animation "Fetching new commits" &
+# Read by gitai_kill_spin from the sourced common runtime.
+# shellcheck disable=SC2034
 SPIN_PID=$!
 # fetch new commits
 git fetch "$BASE_REMOTE"
 if [ "$HEAD_REMOTE" != "$BASE_REMOTE" ]; then
     git fetch "$HEAD_REMOTE"
 fi
-kill_spin
+gitai_kill_spin
 
 HEAD_URL=$(remote_2_url "$HEAD_REMOTE")
 if ! HEAD_VIEW=$(gh repo view --json defaultBranchRef,name,owner "$HEAD_URL"); then

--- a/aitag
+++ b/aitag
@@ -1,66 +1,24 @@
 #!/usr/bin/env bash
 # Thanks Harper Reed https://harper.blog/2024/03/11/use-an-llm-to-automagically-generate-meaningful-git-commit-messages/
 
-# ANSI color codes for styling the output
-RED='\033[0;31m'    # Sets text to red
-YELLOW='\033[0;33m' # Sets text to yellow
-NC='\033[0m'        # Resets the text color to default, no color
+GITAI_SCRIPT_PATH=${BASH_SOURCE[0]}
+while [ -L "$GITAI_SCRIPT_PATH" ]; do
+    GITAI_SCRIPT_DIR=$(cd -- "$(dirname -- "$GITAI_SCRIPT_PATH")" && pwd)
+    GITAI_SCRIPT_PATH=$(readlink "$GITAI_SCRIPT_PATH")
+    case "$GITAI_SCRIPT_PATH" in
+        /*) ;;
+        *) GITAI_SCRIPT_PATH="$GITAI_SCRIPT_DIR/$GITAI_SCRIPT_PATH" ;;
+    esac
+done
+GITAI_SCRIPT_DIR=$(cd -- "$(dirname -- "$GITAI_SCRIPT_PATH")" && pwd)
+GITAI_COMMON_SCRIPT="$GITAI_SCRIPT_DIR/gitai-common.sh"
+if [ ! -r "$GITAI_COMMON_SCRIPT" ]; then
+    echo "Error: gitai-common.sh is not installed next to aitag." >&2
+    exit 1
+fi
+. "$GITAI_COMMON_SCRIPT"
 
 DEFAULT_PROMPT_FILE=$HOME/.config/gitai/prompts/aitag-prompt.txt
-
-check_required_commands() {
-    local missing=0
-    for cmd in git pi; do
-        if ! command -v "$cmd" >/dev/null 2>&1; then
-            echo "Error: $cmd is not installed"
-            missing=$((missing + 1))
-        fi
-    done
-    return $missing
-}
-
-cleanup() {
-    echo -e "\n${RED}Script interrupted. Cleaning up...${NC}"
-    kill_spin
-    tput cnorm # Show the cursor
-    exit 1
-}
-
-# Function to display a spinning animation during AI processing
-spin_animation() {
-    local msg="$1"
-    # Only show animation if output is going to a terminal
-    if ! [ -t 1 ]; then
-        echo "$1..." # Just show the message without animation
-        return
-    fi
-
-    # Array of spinner characters for the animation
-    local spinner=("⠋" "⠙" "⠹" "⠸" "⠼" "⠴" "⠦" "⠧" "⠇" "⠏")
-    # Infinite loop to keep the animation running
-    while true; do
-        for i in "${spinner[@]}"; do
-            tput civis                                    # Hide the cursor to enhance the animation appearance
-            tput el1                                      # Clear the line from the cursor to the beginning to display the spinner
-            printf "\r${YELLOW}%s${NC} %s..." "$i" "$msg" # Print the spinner and message
-            sleep 0.1                                     # Delay to control the speed of the animation
-            tput cub $((${#msg} + 5))                     # Move the cursor back to reset the spinner position
-        done
-    done
-}
-
-kill_spin() {
-    if [ -n "$SPIN_PID" ]; then
-        kill "$SPIN_PID" 2>/dev/null || true
-        wait "$SPIN_PID" 2>/dev/null || true # Wait for the process to terminate and suppress error messages
-        SPIN_PID=
-        printf "\n"
-    fi
-}
-
-is_git_repo() {
-    git rev-parse --is-inside-work-tree >/dev/null 2>&1
-}
 
 show_help() {
     echo "Usage: aitag [OPTIONS] TAG_NAME [COMMIT]"
@@ -70,19 +28,20 @@ show_help() {
     echo "  -s, --sign            Create a signed tag"
     echo "  -u, --local-user USER Create tag with specific user"
     echo "  --prompt FILE         Use custom prompt file"
-    echo "  --model <model>       pi model or model pattern to use"
+    echo "  --model <model>       Model to use with the selected AI agent"
     echo "  --lang <lang>         Generate content in specified language (default: English)"
     echo "  -h, --help            Show this help message"
     echo
     echo "ENVIRONMENT VARIABLES:"
     echo "  GITAI_TAG_PROMPT       Default prompt file path (default: $DEFAULT_PROMPT_FILE)"
-    echo "  GITAI_MODEL            Set the pi model or model pattern for tag generation"
+    echo "  GITAI_AGENT            AI agent: pi, oh-my-pi, codex, or claude-code (auto-detected when unset)"
+    echo "  GITAI_MODEL            Set the model for tag generation"
     echo "  GITAI_LANG             The language for the generated tag message. Defaults to 'English'."
     echo
     echo "EXAMPLES:"
     echo "  aitag v1.0.0                    # Tag HEAD commit as v1.0.0"
     echo "  aitag -a v1.0.0 abc1234         # Create annotated tag for specific commit"
-    echo "  aitag --model openai/gpt-4o v1.0.0      # Use a specific pi model"
+    echo "  aitag --model openai/gpt-4o v1.0.0      # Use a specific model"
     echo "  GITAI_MODEL=openai/gpt-4o aitag v1.0.0  # Set the model with an environment variable"
 }
 
@@ -101,6 +60,10 @@ init_config() {
 }
 
 init_config
+
+if ! gitai_init_agent_runner "$GITAI_SCRIPT_DIR" aitag; then
+    exit 1
+fi
 
 TAG_OPTS=()
 PROMPT_FILE=${GITAI_TAG_PROMPT:-$DEFAULT_PROMPT_FILE}
@@ -147,14 +110,17 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-trap cleanup SIGINT
+trap gitai_handle_interrupt SIGINT
 
-if ! check_required_commands; then
+if ! gitai_check_required_commands git; then
     echo "Please install missing commands before proceeding" >&2
     exit 1
 fi
+if ! gitai_check_agent_runner; then
+    exit 1
+fi
 
-if ! is_git_repo; then
+if ! gitai_is_git_repo; then
     echo "Not in a Git repository" >&2
     exit 1
 fi
@@ -186,8 +152,10 @@ else
     DIFF=$(git diff "$LAST_TAG"..."$COMMIT")
 fi
 
-MODEL_DISPLAY=${MODEL:-pi default}
-spin_animation "Generating tag message using $MODEL_DISPLAY" &
+MODEL_DISPLAY=${MODEL:-${GITAI_AGENT:-auto-selected agent default}}
+gitai_spin_animation "Generating tag message using $MODEL_DISPLAY" &
+# Read by gitai_kill_spin from the sourced common runtime.
+# shellcheck disable=SC2034
 SPIN_PID=$!
 
 if [ ! -f "$PROMPT_FILE" ]; then
@@ -203,18 +171,14 @@ $PROMPT_CONTENT
 EOF
 )
 
-PI_ARGS=(--print --no-session --no-tools --no-context-files --system-prompt "$PROMPT")
-if [ -n "$MODEL" ]; then
-    PI_ARGS+=(--model "$MODEL")
-fi
-if ! MSG=$(printf '%s\n' "$DIFF" | pi "${PI_ARGS[@]}"); then
-    kill_spin
-    echo -e "${RED}Error: 'pi' command failed to generate the tag message.${NC}" >&2
+if ! MSG=$(printf '%s\n' "$DIFF" | "$AGENT_RUNNER" "$PROMPT" "$MODEL"); then
+    gitai_kill_spin
+    echo -e "${RED}Error: AI agent failed to generate the tag message.${NC}" >&2
     exit 1
 fi
-kill_spin
+gitai_kill_spin
 if [[ -z "${MSG//[[:space:]]/}" ]]; then
-    echo -e "${RED}Error: pi returned an empty tag message.${NC}" >&2
+    echo -e "${RED}Error: AI agent returned an empty tag message.${NC}" >&2
     exit 1
 fi
 

--- a/completions/_aipr
+++ b/completions/_aipr
@@ -10,7 +10,7 @@ _aipr() {
         {-T,--template}'[Specify a PR template file to use]:template:_files' \
         '--prompt-title[Path to PR title prompt template]:file:_files' \
         '--prompt-body[Path to PR body prompt template]:file:_files' \
-        '--model[pi model or model pattern to use]:model:->models' \
+        '--model[model to use with the selected AI agent]:model:->models' \
         '--update-title[Update PR title when editing existing PR]::' \
         '--lang[Generate content in specified language (default: English)]:language:'
 
@@ -28,8 +28,10 @@ _aipr() {
             _describe -t branch 'branch' branch
             ;;
         models)
-            model=($(pi --list-models | awk 'NR > 1 {print $1 "/" $2}'))
-            _describe -t model 'model' model
+            if [[ -z "${GITAI_AGENT:-}" || "$GITAI_AGENT" = pi ]] && (( $+commands[pi] )); then
+                model=($(pi --list-models | awk 'NR > 1 {print $1 "/" $2}'))
+                _describe -t model 'model' model
+            fi
             ;;
     esac
 }

--- a/completions/_aitag
+++ b/completions/_aitag
@@ -8,7 +8,7 @@ _aitag() {
         {-s,--sign}'[Create signed tag]' \
         {-u,--local-user=}'[Create tag with specific user]:user:->users' \
         '--prompt=[Use custom prompt file]:prompt file:_files' \
-        '--model[pi model or model pattern to use]:model:->models' \
+        '--model[model to use with the selected AI agent]:model:->models' \
         '--lang[Generate content in specified language (default: English)]:language:'
 
     case "$state" in
@@ -17,8 +17,10 @@ _aitag() {
             _describe -t user 'user' user
             ;;
         models)
-            model=($(pi --list-models | awk 'NR > 1 {print $1 "/" $2}'))
-            _describe -t model 'model' model
+            if [[ -z "${GITAI_AGENT:-}" || "$GITAI_AGENT" = pi ]] && (( $+commands[pi] )); then
+                model=($(pi --list-models | awk 'NR > 1 {print $1 "/" $2}'))
+                _describe -t model 'model' model
+            fi
             ;;
     esac
 }

--- a/completions/aipr.bash
+++ b/completions/aipr.bash
@@ -38,7 +38,11 @@ _pr_completion() {
             return 0
             ;;
         --model)
-            opts=$(pi --list-models | awk 'NR > 1 {print $1 "/" $2}')
+            if [[ -z "${GITAI_AGENT:-}" || "$GITAI_AGENT" = pi ]] && command -v pi >/dev/null 2>&1; then
+                opts=$(pi --list-models | awk 'NR > 1 {print $1 "/" $2}')
+            else
+                opts=
+            fi
             ;;
     esac
 

--- a/completions/aipr.fish
+++ b/completions/aipr.fish
@@ -1,5 +1,7 @@
 function _aipr_models
-    pi --list-models | awk 'NR > 1 {print $1 "/" $2}'
+    if test -z "$GITAI_AGENT" -o "$GITAI_AGENT" = pi
+        command -q pi; and pi --list-models | awk 'NR > 1 {print $1 "/" $2}'
+    end
 end
 
 function _aipr_bases
@@ -14,6 +16,6 @@ complete -c aipr -s H -l head -x -a "(git branch --format='%(refname:short)')" -
 complete -c aipr -s T -l template -r -F -d "Specify a PR template file to use"
 complete -c aipr -l prompt-title -r -F -d "Path to PR title prompt template"
 complete -c aipr -l prompt-body -r -F -d "Path to PR body prompt template"
-complete -c aipr -l model -x -a "(_aipr_models)" -d "pi model or model pattern to use"
+complete -c aipr -l model -x -a "(_aipr_models)" -d "model to use with the selected AI agent"
 complete -c aipr -l update-title -d "Update PR title when editing existing PR"
 complete -c aipr -l lang -d "Generate content in specified language (default: English)"

--- a/completions/aitag.bash
+++ b/completions/aitag.bash
@@ -24,7 +24,11 @@ _aitag() {
             return 0
             ;;
         --model)
-            opts=$(pi --list-models | awk 'NR > 1 {print $1 "/" $2}')
+            if [[ -z "${GITAI_AGENT:-}" || "$GITAI_AGENT" = pi ]] && command -v pi >/dev/null 2>&1; then
+                opts=$(pi --list-models | awk 'NR > 1 {print $1 "/" $2}')
+            else
+                opts=
+            fi
             COMPREPLY=($(compgen -W "${opts}" -- "${cur}"))
             ;;
     esac

--- a/completions/aitag.fish
+++ b/completions/aitag.fish
@@ -1,5 +1,7 @@
 function _aitag_models
-    pi --list-models | awk 'NR > 1 {print $1 "/" $2}'
+    if test -z "$GITAI_AGENT" -o "$GITAI_AGENT" = pi
+        command -q pi; and pi --list-models | awk 'NR > 1 {print $1 "/" $2}'
+    end
 end
 
 function _aitag_user
@@ -12,5 +14,5 @@ complete -c aitag -s a -l annotate -d "Create annotated tag"
 complete -c aitag -s s -l sign -d "Create signed tag"
 complete -c aitag -s u -l local-user -d "Create tag with specific user" -x -a "(_aitag_user)"
 complete -c aitag -l prompt -d "Use custom prompt file" -r -F
-complete -c aitag -l model -d "pi model or model pattern to use" -x -a "(_aitag_models)"
+complete -c aitag -l model -d "model to use with the selected AI agent" -x -a "(_aitag_models)"
 complete -c aitag -l lang -d "Generate content in specified language (default: English)"

--- a/gitai-agent
+++ b/gitai-agent
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+
+set -u
+
+TEMP_FILES=()
+
+cleanup() {
+    if [ "${#TEMP_FILES[@]}" -gt 0 ]; then
+        rm -f -- "${TEMP_FILES[@]}"
+    fi
+}
+
+trap cleanup EXIT
+
+usage() {
+    echo "Usage: gitai-agent --check | <system-prompt> [model]" >&2
+    exit 2
+}
+
+normalize_agent() {
+    case "$1" in
+        pi) echo pi ;;
+        oh-my-pi | omp) echo oh-my-pi ;;
+        codex) echo codex ;;
+        claude-code | claude) echo claude-code ;;
+        *)
+            echo "Error: Unsupported AI agent '$1'. Supported agents: pi, oh-my-pi, codex, claude-code." >&2
+            return 1
+            ;;
+    esac
+}
+
+agent_command() {
+    case "$1" in
+        pi) echo pi ;;
+        oh-my-pi) echo omp ;;
+        codex) echo codex ;;
+        claude-code) echo claude ;;
+    esac
+}
+
+select_agent() {
+    local agent command
+    if [ -n "${GITAI_AGENT:-}" ]; then
+        agent=$(normalize_agent "$GITAI_AGENT") || return 1
+        command=$(agent_command "$agent")
+        if ! command -v "$command" >/dev/null 2>&1; then
+            echo "Error: Configured AI agent '$GITAI_AGENT' requires the '$command' command, but it is not installed." >&2
+            return 1
+        fi
+        echo "$agent"
+        return 0
+    fi
+
+    for agent in pi oh-my-pi codex claude-code; do
+        command=$(agent_command "$agent")
+        if command -v "$command" >/dev/null 2>&1; then
+            echo "$agent"
+            return 0
+        fi
+    done
+
+    echo "Error: No supported AI agent found. Install pi, oh-my-pi (omp), Codex (codex), or Claude Code (claude), or set GITAI_AGENT." >&2
+    return 1
+}
+
+run_agent() {
+    local agent=$1
+    local prompt=$2
+    local model=$3
+    local input_file
+    local -a args
+
+    case "$agent" in
+        pi)
+            args=(--print --no-session --no-tools --no-context-files --system-prompt "$prompt")
+            [ -n "$model" ] && args+=(--model "$model")
+            pi "${args[@]}"
+            ;;
+        oh-my-pi)
+            args=(--print --no-session --no-tools --no-rules --no-skills --no-extensions --system-prompt "$prompt")
+            [ -n "$model" ] && args+=(--model "$model")
+            if ! input_file=$(mktemp "${TMPDIR:-/tmp}/gitai-agent.XXXXXX"); then
+                echo "Error: Failed to create a temporary input file for oh-my-pi." >&2
+                return 1
+            fi
+            TEMP_FILES+=("$input_file")
+            if ! cat >"$input_file"; then
+                echo "Error: Failed to prepare input for oh-my-pi." >&2
+                return 1
+            fi
+            omp "${args[@]}" "@$input_file"
+            ;;
+        codex)
+            args=(exec --ephemeral --sandbox read-only --color never)
+            [ -n "$model" ] && args+=(--model "$model")
+            codex "${args[@]}" "$prompt"
+            ;;
+        claude-code)
+            args=(--print --no-session-persistence --system-prompt "$prompt")
+            [ -n "$model" ] && args+=(--model "$model")
+            claude "${args[@]}" "Use the supplied input to complete the task." --tools ""
+            ;;
+    esac
+}
+
+if [ "$#" -eq 1 ] && [ "$1" = --check ]; then
+    select_agent
+    exit $?
+fi
+
+[ "$#" -ge 1 ] && [ "$#" -le 2 ] || usage
+
+PROMPT=$1
+MODEL=${2:-}
+AGENT=$(select_agent) || exit 1
+run_agent "$AGENT" "$PROMPT" "$MODEL"

--- a/gitai-common.sh
+++ b/gitai-common.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+
+# Shared runtime functions for the gitai command entrypoints.
+
+RED='\033[0;31m'
+# Used by entrypoints that source this file.
+# shellcheck disable=SC2034
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+# Used by entrypoints that source this file.
+# shellcheck disable=SC2034
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+SPIN_PID=${SPIN_PID:-}
+
+gitai_spin_animation() {
+    local msg=$1
+    if ! [ -t 1 ]; then
+        echo "$msg..."
+        return
+    fi
+
+    local spinner=("⠋" "⠙" "⠹" "⠸" "⠼" "⠴" "⠦" "⠧" "⠇" "⠏")
+    local i
+    while true; do
+        for i in "${spinner[@]}"; do
+            tput civis
+            tput el1
+            printf "\r${YELLOW}%s${NC} %s..." "$i" "$msg"
+            sleep 0.1
+            tput cub $((${#msg} + 5))
+        done
+    done
+}
+
+gitai_kill_spin() {
+    if [ -n "$SPIN_PID" ]; then
+        kill "$SPIN_PID" 2>/dev/null || true
+        wait "$SPIN_PID" 2>/dev/null || true
+        SPIN_PID=
+        printf "\n"
+    fi
+}
+
+gitai_handle_interrupt() {
+    echo -e "\n${RED}Script interrupted. Cleaning up...${NC}"
+    gitai_kill_spin
+    tput cnorm
+    exit 1
+}
+
+gitai_is_git_repo() {
+    git rev-parse --is-inside-work-tree >/dev/null 2>&1
+}
+
+gitai_check_required_commands() {
+    local missing=0
+    local command
+    for command in "$@"; do
+        if ! command -v "$command" >/dev/null 2>&1; then
+            echo "Error: $command is not installed"
+            missing=$((missing + 1))
+        fi
+    done
+    [ "$missing" -eq 0 ]
+}
+
+gitai_init_agent_runner() {
+    local script_dir=$1
+    local entrypoint=$2
+    AGENT_RUNNER="$script_dir/gitai-agent"
+    if [ ! -x "$AGENT_RUNNER" ]; then
+        echo -e "${RED}Error: gitai-agent is not installed next to $entrypoint.${NC}" >&2
+        return 1
+    fi
+}
+
+gitai_check_agent_runner() {
+    "$AGENT_RUNNER" --check >/dev/null
+}
+
+gitai_extract_json_object() {
+    jq -ceRrs '
+        . as $raw
+        | first(
+            ($raw | fromjson? | select(type == "object")),
+            ($raw
+                | sub("^\\s*```(?:json)?\\s*"; "")
+                | sub("\\s*```\\s*$"; "")
+                | fromjson?
+                | select(type == "object")),
+            ($raw | split("\n")[] | fromjson? | select(type == "object")),
+            ($raw
+                | try capture("(?s)(?<json>\\{.*\\})").json catch empty
+                | fromjson?
+                | select(type == "object"))
+        )
+    '
+}

--- a/scripts/brew-dev-link
+++ b/scripts/brew-dev-link
@@ -7,7 +7,7 @@ set -euo pipefail
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 PROJECT_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
 FORMULA=gitai
-COMMANDS=(aipr aitag ai-commit-msg)
+COMMANDS=(aipr aitag ai-commit-msg gitai-agent gitai-common.sh)
 
 usage() {
     cat <<EOF

--- a/tests/integration-github.sh
+++ b/tests/integration-github.sh
@@ -1,0 +1,298 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+PROJECT_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+KEEP_REPO=0
+REMOTE_CREATED=0
+REPO_SLUG=
+REPO_URL=
+TEST_ROOT=
+PR_URLS=()
+AGENTS=(pi oh-my-pi codex claude-code)
+
+usage() {
+    cat <<'EOF'
+Usage: tests/integration-github.sh [--keep-repo]
+
+Run real end-to-end tests against pi, oh-my-pi, codex, and claude-code.
+For every agent, the test covers ai-commit-msg, aitag, and aipr, then verifies
+the pushed branch, pushed tag, and pull request content through GitHub.
+
+Options:
+  --keep-repo  Keep the temporary GitHub repository for manual verification.
+  -h, --help   Show this help message.
+
+By default both the local temporary directory and GitHub repository are removed.
+The active gh account must be able to create and delete private repositories.
+EOF
+}
+
+log() {
+    printf '==> %s\n' "$*"
+}
+
+fail() {
+    echo "Error: $*" >&2
+    exit 1
+}
+
+cleanup() {
+    local status=$?
+    local cleanup_failed=0
+    trap - EXIT
+
+    if [ -n "$TEST_ROOT" ] && [ -d "$TEST_ROOT" ]; then
+        rm -rf -- "$TEST_ROOT"
+    fi
+
+    if [ "$REMOTE_CREATED" = 1 ]; then
+        if [ "$KEEP_REPO" = 1 ]; then
+            printf '\nGitHub repository retained for manual verification:\n  %s\n' "$REPO_URL"
+            if [ "${#PR_URLS[@]}" -gt 0 ]; then
+                printf 'Pull requests:\n'
+                printf '  %s\n' "${PR_URLS[@]}"
+            fi
+        else
+            log "Deleting GitHub repository $REPO_SLUG"
+            if ! gh repo delete "$REPO_SLUG" --yes; then
+                cleanup_failed=1
+                printf 'Error: Failed to delete %s. Delete it manually with:\n  gh repo delete %q --yes\n' \
+                    "$REPO_SLUG" "$REPO_SLUG" >&2
+            fi
+        fi
+    fi
+
+    if [ "$status" -eq 0 ] && [ "$cleanup_failed" -ne 0 ]; then
+        status=1
+    fi
+    exit "$status"
+}
+
+require_command() {
+    command -v "$1" >/dev/null 2>&1 || fail "Required command '$1' is not installed."
+}
+
+assert_contains() {
+    local value=$1
+    local expected=$2
+    local description=$3
+    case "$value" in
+        *"$expected"*) ;;
+        *) fail "$description does not contain expected marker '$expected'. Actual value: $value" ;;
+    esac
+}
+
+agent_command() {
+    case "$1" in
+        pi) echo pi ;;
+        oh-my-pi) echo omp ;;
+        codex) echo codex ;;
+        claude-code) echo claude ;;
+    esac
+}
+
+write_prompts() {
+    local agent=$1
+    local commit_marker=$2
+    local tag_marker=$3
+    local title_marker=$4
+    local body_marker=$5
+
+    cat >"$TEST_ROOT/commit-$agent.txt" <<EOF
+Generate a concise Git commit message for the supplied diff.
+The response must contain this exact verification marker: $commit_marker
+Return only the commit message, without Markdown fences or commentary.
+EOF
+
+    cat >"$TEST_ROOT/tag-$agent.txt" <<EOF
+Generate a concise annotated Git tag message for the supplied diff.
+The response must contain this exact verification marker: $tag_marker
+Return only the tag message, without Markdown fences or commentary.
+EOF
+
+    cat >"$TEST_ROOT/pr-title-$agent.txt" <<EOF
+Generate a concise pull request title.
+The title must contain this exact verification marker: $title_marker
+EOF
+
+    cat >"$TEST_ROOT/pr-body-$agent.txt" <<EOF
+Generate a clear pull request body.
+The body must contain this exact verification marker: $body_marker
+EOF
+}
+
+run_agent_test() {
+    local agent=$1
+    local index=$2
+    local repo_dir=$3
+    local branch="integration-$agent"
+    local tag="gitai-integration-v$index"
+    local marker_prefix="GITAI_E2E_${agent//-/_}_${RUN_ID}"
+    local commit_marker="${marker_prefix}_COMMIT"
+    local tag_marker="${marker_prefix}_TAG"
+    local title_marker="${marker_prefix}_PR_TITLE"
+    local body_marker="${marker_prefix}_PR_BODY"
+    local message_file="$TEST_ROOT/commit-message-$agent"
+    local pr_output="$TEST_ROOT/aipr-$agent.log"
+    local commit_message tag_message local_sha remote_sha pr_json pr_url
+
+    log "Testing $agent with ai-commit-msg, aitag, and aipr"
+    write_prompts "$agent" "$commit_marker" "$tag_marker" "$title_marker" "$body_marker"
+
+    git -C "$repo_dir" switch -q main
+    git -C "$repo_dir" switch -q -c "$branch"
+    printf 'integration change generated for %s\n' "$agent" >"$repo_dir/change-$agent.txt"
+    git -C "$repo_dir" add "change-$agent.txt"
+    : >"$message_file"
+
+    (
+        cd "$repo_dir"
+        EDITOR=true \
+            GITAI_AGENT="$agent" \
+            GITAI_MODEL='' \
+            GITAI_LANG=English \
+            GITAI_COMMIT_MSG_PROMPT="$TEST_ROOT/commit-$agent.txt" \
+            "$PROJECT_ROOT/ai-commit-msg" "$message_file"
+    )
+    commit_message=$(cat "$message_file")
+    assert_contains "$commit_message" "$commit_marker" "$agent commit message"
+    git -C "$repo_dir" commit -q -F "$message_file"
+
+    printf 'y\n' | (
+        cd "$repo_dir"
+        EDITOR=true \
+            GITAI_AGENT="$agent" \
+            GITAI_MODEL='' \
+            GITAI_LANG=English \
+            GITAI_TAG_PROMPT="$TEST_ROOT/tag-$agent.txt" \
+            "$PROJECT_ROOT/aitag" --annotate "$tag"
+    )
+    tag_message=$(git -C "$repo_dir" for-each-ref --format='%(contents)' "refs/tags/$tag")
+    assert_contains "$tag_message" "$tag_marker" "$agent tag message"
+
+    git -C "$repo_dir" push -q -u origin "$branch"
+    git -C "$repo_dir" push -q origin "refs/tags/$tag"
+
+    local_sha=$(git -C "$repo_dir" rev-parse "$branch")
+    remote_sha=$(git -C "$repo_dir" ls-remote origin "refs/heads/$branch" | awk '{print $1}')
+    [ "$local_sha" = "$remote_sha" ] || fail "$agent branch was not pushed at the expected commit."
+    git -C "$repo_dir" ls-remote --exit-code origin "refs/tags/$tag" >/dev/null || \
+        fail "$agent tag was not pushed to GitHub."
+
+    printf 'y\n' | (
+        cd "$repo_dir"
+        EDITOR=true \
+            GITAI_AGENT="$agent" \
+            GITAI_MODEL='' \
+            GITAI_LANG=English \
+            GITAI_PR_PROMPT_TITLE="$TEST_ROOT/pr-title-$agent.txt" \
+            GITAI_PR_PROMPT_BODY="$TEST_ROOT/pr-body-$agent.txt" \
+            "$PROJECT_ROOT/aipr" --base main
+    ) >"$pr_output"
+
+    pr_json=$(gh pr view "$branch" --repo "$REPO_SLUG" \
+        --json url,title,body,state,headRefName,baseRefName)
+    printf '%s\n' "$pr_json" | jq -e \
+        --arg title_marker "$title_marker" \
+        --arg body_marker "$body_marker" \
+        --arg branch "$branch" \
+        '.state == "OPEN"
+         and .headRefName == $branch
+         and .baseRefName == "main"
+         and (.title | contains($title_marker))
+         and (.body | contains($body_marker))' >/dev/null || \
+        fail "$agent pull request did not match the expected title, body, state, or branches: $pr_json"
+
+    pr_url=$(printf '%s\n' "$pr_json" | jq -r '.url')
+    PR_URLS+=("$agent: $pr_url")
+    log "$agent passed: $pr_url"
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --keep-repo)
+            KEEP_REPO=1
+            shift
+            ;;
+        -h | --help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown option: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+for command in git gh jq awk; do
+    require_command "$command"
+done
+for agent in "${AGENTS[@]}"; do
+    require_command "$(agent_command "$agent")"
+done
+for command in ai-commit-msg aitag aipr gitai-agent gitai-common.sh; do
+    [ -x "$PROJECT_ROOT/$command" ] || fail "$PROJECT_ROOT/$command is not executable."
+done
+CLAUDE_AUTH_JSON=$(claude auth status 2>&1) || \
+    fail "Claude Code is not authenticated. Run 'claude auth login' first."
+printf '%s\n' "$CLAUDE_AUTH_JSON" | jq -e '.loggedIn == true' >/dev/null 2>&1 || \
+    fail "Claude Code is not authenticated. Run 'claude auth login' first."
+AUTH_JSON=$(gh auth status --active --hostname github.com --json hosts 2>/dev/null) || \
+    fail "Could not inspect gh authentication. Run 'gh auth login' first."
+AUTH_STATE=$(printf '%s\n' "$AUTH_JSON" | jq -r \
+    '.hosts["github.com"][] | select(.active == true) | .state' | head -n1)
+[ "$AUTH_STATE" = success ] || fail "gh is not authenticated for github.com. Run 'gh auth login' first."
+
+if [ "$KEEP_REPO" = 0 ]; then
+    AUTH_SCOPES=$(printf '%s\n' "$AUTH_JSON" | jq -r \
+        '.hosts["github.com"][] | select(.active == true) | .scopes // ""' | head -n1)
+    NORMALIZED_SCOPES=${AUTH_SCOPES// /}
+    if [ -n "$NORMALIZED_SCOPES" ]; then
+        case ",$NORMALIZED_SCOPES," in
+            *,delete_repo,*) ;;
+            *)
+                fail "Default cleanup requires the delete_repo scope. Run 'gh auth refresh -h github.com -s delete_repo', or use --keep-repo."
+                ;;
+        esac
+    fi
+fi
+
+TEST_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/gitai-integration.XXXXXX")
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+RUN_ID="$(date -u +%Y%m%d%H%M%S)-$$-$RANDOM"
+OWNER=$(gh api user --jq '.login')
+[ -n "$OWNER" ] || fail "Could not determine the active GitHub account."
+REPO_NAME="gitai-integration-$RUN_ID"
+REPO_SLUG="$OWNER/$REPO_NAME"
+REPO_URL="https://github.com/$REPO_SLUG"
+REPO_DIR="$TEST_ROOT/repo"
+
+if gh repo view "$REPO_SLUG" >/dev/null 2>&1; then
+    fail "Refusing to use existing repository $REPO_SLUG."
+fi
+
+log "Creating private GitHub repository $REPO_SLUG"
+gh repo create "$REPO_SLUG" --private --description "Temporary gitai integration test repository"
+REMOTE_CREATED=1
+gh repo clone "$REPO_SLUG" "$REPO_DIR"
+git -C "$REPO_DIR" config user.name "gitai integration test"
+git -C "$REPO_DIR" config user.email "gitai-integration@example.invalid"
+git -C "$REPO_DIR" symbolic-ref HEAD refs/heads/main
+printf 'gitai integration test repository\n' >"$REPO_DIR/README.md"
+git -C "$REPO_DIR" add README.md
+git -C "$REPO_DIR" commit -q -m "chore: initialize integration repository"
+git -C "$REPO_DIR" push -q -u origin main
+
+index=1
+for agent in "${AGENTS[@]}"; do
+    run_agent_test "$agent" "$index" "$REPO_DIR"
+    index=$((index + 1))
+done
+
+printf '\nAll GitHub integration tests passed for: %s\n' "${AGENTS[*]}"

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -20,8 +20,8 @@ assert_contains() {
 assert_call_count() {
     local expected=$1
     local actual
-    actual=$(find "$PI_CALLS" -type f -name 'args.*' | wc -l | tr -d ' ')
-    [ "$actual" = "$expected" ] || fail "Expected $expected pi call(s), got $actual"
+    actual=$(find "$AGENT_CALLS" -type f -name 'args.*' | wc -l | tr -d ' ')
+    [ "$actual" = "$expected" ] || fail "Expected $expected agent call(s), got $actual"
 }
 
 setup_home() {
@@ -34,7 +34,8 @@ setup_stubs() {
     local name=$1
     STUB_DIR="$TEST_ROOT/stubs-$name"
     PI_CALLS="$TEST_ROOT/pi-calls-$name"
-    export PI_CALLS
+    AGENT_CALLS=$PI_CALLS
+    export PI_CALLS AGENT_CALLS
     mkdir -p "$STUB_DIR" "$PI_CALLS"
 
     cat >"$STUB_DIR/pi" <<'EOF'
@@ -55,6 +56,36 @@ fi
 EOF
     chmod +x "$STUB_DIR/pi"
     export PATH="$STUB_DIR:$PATH"
+}
+
+stub_agent() {
+    local command=$1
+    local response=${2:-feat: use selected agent}
+    cat >"$STUB_DIR/$command" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+call=\$(find "\$AGENT_CALLS" -type f -name 'args.*' | wc -l | tr -d ' ')
+call=\$((call + 1))
+printf '%s\n' "\$@" >"\$AGENT_CALLS/args.\$call"
+cat >"\$AGENT_CALLS/stdin.\$call"
+if [ "\$(basename "\$0")" = omp ]; then
+    echo "Working..." >&2
+fi
+for arg in "\$@"; do
+    case "\$arg" in
+        @*)
+            attachment=\${arg#@}
+            [ -f "\$attachment" ] && cat "\$attachment" >"\$AGENT_CALLS/attachment.\$call"
+            ;;
+    esac
+done
+if [ "\${AGENT_FAIL_STDOUT:-}" = 1 ]; then
+    echo "agent failure written to stdout"
+    exit 1
+fi
+printf '%s\n' '$response'
+EOF
+    chmod +x "$STUB_DIR/$command"
 }
 
 init_repo() {
@@ -78,7 +109,7 @@ test_commit_message_uses_pi() {
 
     (
         cd "$repo"
-        EDITOR=true GITAI_MODEL=google/test-model "$PROJECT_ROOT/ai-commit-msg" message
+        EDITOR=true GITAI_AGENT=pi GITAI_MODEL=google/test-model "$PROJECT_ROOT/ai-commit-msg" message
     )
 
     assert_call_count 1
@@ -99,7 +130,7 @@ test_tag_uses_pi() {
 
     printf 'n\n' | (
         cd "$repo"
-        EDITOR=true GITAI_MODEL=google/test-model "$PROJECT_ROOT/aitag" v1.0.0
+        EDITOR=true GITAI_AGENT=pi GITAI_MODEL=google/test-model "$PROJECT_ROOT/aitag" v1.0.0
     )
 
     assert_call_count 1
@@ -119,12 +150,12 @@ test_tag_rejects_empty_pi_response() {
 
     if printf 'n\n' | (
         cd "$repo"
-        EDITOR=true PI_EMPTY_RESPONSE=1 "$PROJECT_ROOT/aitag" v1.0.0
+        EDITOR=true GITAI_AGENT=pi PI_EMPTY_RESPONSE=1 "$PROJECT_ROOT/aitag" v1.0.0
     ) >"$output" 2>&1; then
         fail "Expected aitag to reject an empty pi response"
     fi
 
-    assert_contains "$output" "pi returned an empty tag message"
+    assert_contains "$output" "AI agent returned an empty tag message"
     [ -z "$(git -C "$repo" tag --list)" ] || fail "An empty tag message must not create a tag"
     echo "ok - aitag rejects an empty pi response"
 }
@@ -165,7 +196,7 @@ EOF
 
     printf 'n\n' | (
         cd "$repo"
-        EDITOR=true GITAI_MODEL=google/test-model "$PROJECT_ROOT/aipr"
+        EDITOR=true GITAI_AGENT=pi GITAI_MODEL=google/test-model "$PROJECT_ROOT/aipr"
     ) >"$TEST_ROOT/aipr-output"
 
     assert_call_count 1
@@ -180,7 +211,7 @@ EOF
 
     printf 'n\n' | (
         cd "$repo"
-        EDITOR=true GH_ONGOING=42 GITAI_MODEL=google/test-model "$PROJECT_ROOT/aipr" --update-title
+        EDITOR=true GH_ONGOING=42 GITAI_AGENT=pi GITAI_MODEL=google/test-model "$PROJECT_ROOT/aipr" --update-title
     ) >"$TEST_ROOT/aipr-update-output"
 
     assert_call_count 2
@@ -189,6 +220,177 @@ EOF
     assert_contains "$TEST_ROOT/aipr-update-output" "Improve pi integration"
     assert_contains "$TEST_ROOT/aipr-update-output" "Use pi once"
     echo "ok - aipr updates title and body with one pi call"
+}
+
+test_configured_agents_use_their_cli_contract() {
+    local configured command expected
+    for configured in oh-my-pi codex claude-code; do
+        setup_home "agent-$configured"
+        setup_stubs "agent-$configured"
+        case "$configured" in
+            oh-my-pi)
+                command=omp
+                expected=--no-tools
+                ;;
+            codex)
+                command=codex
+                expected=--ephemeral
+                ;;
+            claude-code)
+                command=claude
+                expected=--no-session-persistence
+                ;;
+        esac
+        rm "$STUB_DIR/pi"
+        stub_agent "$command"
+        local repo="$TEST_ROOT/agent-$configured-repo"
+        init_repo "$repo"
+        echo changed >"$repo/file.txt"
+        git -C "$repo" add file.txt
+        : >"$repo/message"
+
+        (
+            cd "$repo"
+            EDITOR=true GITAI_AGENT="$configured" GITAI_MODEL=test-model \
+                "$PROJECT_ROOT/ai-commit-msg" message
+        )
+
+        assert_call_count 1
+        assert_contains "$AGENT_CALLS/args.1" "$expected"
+        assert_contains "$AGENT_CALLS/args.1" "test-model"
+        if [ "$configured" = oh-my-pi ]; then
+            [ -f "$AGENT_CALLS/attachment.1" ] || fail "Expected oh-my-pi input to be passed as an @file attachment"
+            assert_contains "$AGENT_CALLS/attachment.1" "+changed"
+            if grep -F "Working..." "$repo/message" >/dev/null; then
+                fail "Expected oh-my-pi progress output to stay out of the commit message"
+            fi
+        else
+            assert_contains "$AGENT_CALLS/stdin.1" "+changed"
+        fi
+        if [ "$configured" = claude-code ]; then
+            assert_contains "$AGENT_CALLS/args.1" "Use the supplied input to complete the task."
+            local prompt_line tools_line
+            prompt_line=$(grep -nFx "Use the supplied input to complete the task." "$AGENT_CALLS/args.1" | cut -d: -f1)
+            tools_line=$(grep -nFx -- "--tools" "$AGENT_CALLS/args.1" | cut -d: -f1)
+            [ "$prompt_line" -lt "$tools_line" ] || \
+                fail "Expected the Claude prompt before the variadic --tools option"
+        fi
+    done
+    echo "ok - configured agents use their CLI contracts"
+}
+
+test_agent_stdout_failure_is_reported() {
+    setup_home agent-stdout-failure
+    setup_stubs agent-stdout-failure
+    rm "$STUB_DIR/pi"
+    stub_agent claude
+    local repo="$TEST_ROOT/agent-stdout-failure-repo"
+    local output="$TEST_ROOT/agent-stdout-failure-output"
+    init_repo "$repo"
+    echo changed >"$repo/file.txt"
+    git -C "$repo" add file.txt
+    : >"$repo/message"
+
+    if (
+        cd "$repo"
+        EDITOR=true AGENT_FAIL_STDOUT=1 GITAI_AGENT=claude-code \
+            "$PROJECT_ROOT/ai-commit-msg" message
+    ) >"$output" 2>&1; then
+        fail "Expected an agent failure written to stdout to fail"
+    fi
+    assert_contains "$output" "agent failure written to stdout"
+    echo "ok - agent failures written to stdout are reported"
+}
+
+test_agent_auto_detection_order() {
+    setup_home agent-detection
+    setup_stubs agent-detection
+    stub_agent omp
+    stub_agent codex
+    stub_agent claude
+    local repo="$TEST_ROOT/agent-detection-repo"
+    init_repo "$repo"
+    echo changed >"$repo/file.txt"
+    git -C "$repo" add file.txt
+    : >"$repo/message"
+
+    (
+        cd "$repo"
+        PATH="$STUB_DIR:/usr/bin:/bin" EDITOR=true "$PROJECT_ROOT/ai-commit-msg" message
+    )
+    assert_contains "$AGENT_CALLS/args.1" "--no-context-files"
+
+    rm "$STUB_DIR/pi"
+    : >"$repo/message"
+    (
+        cd "$repo"
+        PATH="$STUB_DIR:/usr/bin:/bin" EDITOR=true "$PROJECT_ROOT/ai-commit-msg" message
+    )
+    assert_contains "$AGENT_CALLS/args.2" "--no-rules"
+
+    rm "$STUB_DIR/omp"
+    : >"$repo/message"
+    (
+        cd "$repo"
+        PATH="$STUB_DIR:/usr/bin:/bin" EDITOR=true "$PROJECT_ROOT/ai-commit-msg" message
+    )
+    assert_contains "$AGENT_CALLS/args.3" "--ephemeral"
+
+    rm "$STUB_DIR/codex"
+    : >"$repo/message"
+    (
+        cd "$repo"
+        PATH="$STUB_DIR:/usr/bin:/bin" EDITOR=true "$PROJECT_ROOT/ai-commit-msg" message
+    )
+    assert_contains "$AGENT_CALLS/args.4" "--no-session-persistence"
+    echo "ok - agent auto-detection follows pi, oh-my-pi, codex, claude-code order"
+}
+
+test_commit_hook_resolves_runner_through_symlink() {
+    setup_home symlink-hook
+    setup_stubs symlink-hook
+    local repo="$TEST_ROOT/symlink-hook-repo"
+    init_repo "$repo"
+    mkdir "$repo/hooks"
+    ln -s "$PROJECT_ROOT/ai-commit-msg" "$repo/hooks/prepare-commit-msg"
+    echo changed >"$repo/file.txt"
+    git -C "$repo" add file.txt
+    : >"$repo/message"
+
+    (
+        cd "$repo"
+        GITAI_AGENT=pi "$repo/hooks/prepare-commit-msg" message
+    )
+    assert_call_count 1
+    echo "ok - commit hook resolves the agent runner through a symlink"
+}
+
+test_no_available_agent_is_an_error() {
+    setup_home no-agent
+    local repo="$TEST_ROOT/no-agent-repo"
+    local output="$TEST_ROOT/no-agent-output"
+    init_repo "$repo"
+    echo changed >"$repo/file.txt"
+    git -C "$repo" add file.txt
+    : >"$repo/message"
+
+    if (
+        cd "$repo"
+        PATH=/usr/bin:/bin EDITOR=true "$PROJECT_ROOT/ai-commit-msg" message
+    ) >"$output" 2>&1; then
+        fail "Expected ai-commit-msg to fail when no supported agent is installed"
+    fi
+    assert_contains "$output" "No supported AI agent found"
+    echo "ok - missing agents produce a clear error"
+}
+
+test_configured_unavailable_agent_is_an_error() {
+    local output="$TEST_ROOT/unavailable-agent-output"
+    if PATH=/usr/bin:/bin GITAI_AGENT=codex "$PROJECT_ROOT/gitai-agent" --check >"$output" 2>&1; then
+        fail "Expected an unavailable configured agent to fail"
+    fi
+    assert_contains "$output" "Configured AI agent 'codex' requires the 'codex' command"
+    echo "ok - unavailable configured agent produces a clear error"
 }
 
 test_model_help_is_consistent() {
@@ -206,9 +408,9 @@ test_model_help_is_consistent() {
     ) >"$aitag_help"
 
     assert_contains "$aipr_help" "--model <model>"
-    assert_contains "$aipr_help" "pi model or model pattern to use"
+    assert_contains "$aipr_help" "Model to use with the selected AI agent"
     assert_contains "$aitag_help" "--model <model>"
-    assert_contains "$aitag_help" "pi model or model pattern to use"
+    assert_contains "$aitag_help" "Model to use with the selected AI agent"
     echo "ok - --model help is consistent"
 }
 
@@ -240,7 +442,7 @@ EOF
         "$PROJECT_ROOT/scripts/brew-dev-link" link
 
     assert_contains "$brew_log" "unlink gitai"
-    for command in aipr aitag ai-commit-msg; do
+    for command in aipr aitag ai-commit-msg gitai-agent gitai-common.sh; do
         [ -L "$brew_prefix/bin/$command" ] || fail "Expected a development link for $command"
         [ "$(readlink "$brew_prefix/bin/$command")" = "$PROJECT_ROOT/$command" ] || \
             fail "Development link for $command has the wrong target"
@@ -250,15 +452,164 @@ EOF
         "$PROJECT_ROOT/scripts/brew-dev-link" restore
 
     assert_contains "$brew_log" "link gitai"
-    for command in aipr aitag ai-commit-msg; do
+    for command in aipr aitag ai-commit-msg gitai-agent gitai-common.sh; do
         [ ! -e "$brew_prefix/bin/$command" ] || fail "Expected development link for $command to be removed"
     done
     echo "ok - brew development links can be restored"
+}
+
+test_github_integration_script_cli() {
+    local help_output="$TEST_ROOT/github-integration-help"
+    local error_output="$TEST_ROOT/github-integration-error"
+
+    "$PROJECT_ROOT/tests/integration-github.sh" --help >"$help_output"
+    assert_contains "$help_output" "--keep-repo"
+    assert_contains "$help_output" "pi, oh-my-pi, codex, and claude-code"
+    assert_contains "$help_output" "ai-commit-msg, aitag, and aipr"
+
+    if "$PROJECT_ROOT/tests/integration-github.sh" --unknown >"$error_output" 2>&1; then
+        fail "Expected the GitHub integration script to reject unknown flags"
+    fi
+    assert_contains "$error_output" "Unknown option: --unknown"
+    echo "ok - GitHub integration script exposes a safe CLI"
+}
+
+test_github_integration_requires_cleanup_permission() {
+    local stub_dir="$TEST_ROOT/github-integration-stubs"
+    local output="$TEST_ROOT/github-integration-auth-error"
+    local gh_log="$TEST_ROOT/github-integration-gh.log"
+    mkdir -p "$stub_dir"
+
+    for command in pi omp codex; do
+        cat >"$stub_dir/$command" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+        chmod +x "$stub_dir/$command"
+    done
+
+    cat >"$stub_dir/claude" <<'EOF'
+#!/usr/bin/env bash
+if [ "$1 $2" = "auth status" ]; then
+    printf '%s\n' '{"loggedIn":true,"authMethod":"test"}'
+fi
+exit 0
+EOF
+    chmod +x "$stub_dir/claude"
+
+    cat >"$stub_dir/gh" <<'EOF'
+#!/usr/bin/env bash
+if [ "$1 $2" = "auth status" ]; then
+    printf '%s\n' '{"hosts":{"github.com":[{"state":"success","active":true,"scopes":"repo, read:org"}]}}'
+    exit 0
+fi
+printf '%s\n' "$*" >>"$TEST_GH_LOG"
+exit 99
+EOF
+    chmod +x "$stub_dir/gh"
+
+    if PATH="$stub_dir:$PATH" TEST_GH_LOG="$gh_log" \
+        "$PROJECT_ROOT/tests/integration-github.sh" >"$output" 2>&1; then
+        fail "Expected GitHub integration to require repository cleanup permission"
+    fi
+    assert_contains "$output" "delete_repo"
+    [ ! -e "$gh_log" ] || fail "GitHub integration created resources before checking cleanup permission"
+    echo "ok - GitHub integration checks cleanup permission before creating resources"
+}
+
+test_github_integration_checks_claude_auth_before_creating_repo() {
+    local stub_dir="$TEST_ROOT/github-claude-auth-stubs"
+    local output="$TEST_ROOT/github-claude-auth-error"
+    local gh_log="$TEST_ROOT/github-claude-auth-gh.log"
+    mkdir -p "$stub_dir"
+
+    for command in pi omp codex; do
+        cat >"$stub_dir/$command" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+        chmod +x "$stub_dir/$command"
+    done
+
+    cat >"$stub_dir/claude" <<'EOF'
+#!/usr/bin/env bash
+if [ "$1 $2" = "auth status" ]; then
+    printf '%s\n' '{"loggedIn":false,"authMethod":"none"}'
+    exit 1
+fi
+exit 0
+EOF
+    chmod +x "$stub_dir/claude"
+
+    cat >"$stub_dir/gh" <<'EOF'
+#!/usr/bin/env bash
+if [ "$1 $2" = "auth status" ]; then
+    printf '%s\n' '{"hosts":{"github.com":[{"state":"success","active":true,"scopes":"repo"}]}}'
+    exit 0
+fi
+printf '%s\n' "$*" >>"$TEST_GH_LOG"
+exit 99
+EOF
+    chmod +x "$stub_dir/gh"
+
+    if PATH="$stub_dir:$PATH" TEST_GH_LOG="$gh_log" \
+        "$PROJECT_ROOT/tests/integration-github.sh" --keep-repo >"$output" 2>&1; then
+        fail "Expected GitHub integration to reject unauthenticated Claude Code"
+    fi
+    assert_contains "$output" "claude auth login"
+    [ ! -e "$gh_log" ] || fail "GitHub integration created resources before checking Claude authentication"
+    echo "ok - GitHub integration checks Claude authentication before creating resources"
+}
+
+test_entrypoints_load_shared_functions() {
+    local common="$PROJECT_ROOT/gitai-common.sh"
+    [ -f "$common" ] || fail "Expected shared functions in gitai-common.sh"
+
+    for entrypoint in ai-commit-msg aipr aitag; do
+        # The assertion intentionally searches for a literal shell variable reference.
+        # shellcheck disable=SC2016
+        assert_contains "$PROJECT_ROOT/$entrypoint" '. "$GITAI_COMMON_SCRIPT"'
+        if grep -E '^(spin_animation|kill_spin|cleanup|check_required_commands|is_git_repo)\(\)' \
+            "$PROJECT_ROOT/$entrypoint" >/dev/null; then
+            fail "Expected $entrypoint to use shared common functions"
+        fi
+    done
+    echo "ok - entrypoints load shared functions"
+}
+
+test_shared_json_response_extraction() {
+    # Loaded dynamically from the checkout under test.
+    # shellcheck disable=SC1091
+    . "$PROJECT_ROOT/gitai-common.sh"
+    local expected='{"title":"Expected title","body":"Expected body"}'
+    local actual
+
+    actual=$(printf 'Claude status output\n%s\nDone\n' "$expected" | gitai_extract_json_object)
+    [ "$(printf '%s\n' "$actual" | jq -c .)" = "$expected" ] || \
+        fail "Expected JSON extraction to ignore surrounding text"
+
+    # Backticks are literal Markdown fence characters.
+    # shellcheck disable=SC2016
+    actual=$(printf '```json\n%s\n```\n' "$expected" | gitai_extract_json_object)
+    [ "$(printf '%s\n' "$actual" | jq -c .)" = "$expected" ] || \
+        fail "Expected JSON extraction to remove a Markdown fence"
+    echo "ok - shared JSON extraction tolerates agent formatting"
 }
 
 test_commit_message_uses_pi
 test_tag_uses_pi
 test_tag_rejects_empty_pi_response
 test_pr_uses_pi_once_for_title_and_body
+test_configured_agents_use_their_cli_contract
+test_agent_stdout_failure_is_reported
+test_agent_auto_detection_order
+test_commit_hook_resolves_runner_through_symlink
+test_no_available_agent_is_an_error
+test_configured_unavailable_agent_is_an_error
 test_model_help_is_consistent
 test_brew_development_links_can_be_restored
+test_github_integration_script_cli
+test_github_integration_requires_cleanup_permission
+test_github_integration_checks_claude_auth_before_creating_repo
+test_entrypoints_load_shared_functions
+test_shared_json_response_extraction


### PR DESCRIPTION
## Summary

Add configurable multi-agent support across `ai-commit-msg`, `aipr`, and `aitag`, covering Pi, Oh My Pi, Codex, and Claude Code.

## Changes

- add `GITAI_AGENT` selection, aliases, availability checks, and automatic fallback order
- adapt each agent's non-interactive input/output contract
- extract shared shell functions into `gitai-common.sh`
- normalize structured PR responses, including fenced or surrounding agent output
- add reusable regression tests and an optional real GitHub integration suite with automatic cleanup and `--keep-repo`
- update documentation, completions, and Homebrew development links

## Testing

- `./tests/run.sh`
- Bash, Fish, and Zsh syntax checks
- ShellCheck (excluding SC1090 for runtime-sourced files and SC2207 in completion scripts)
- `git diff --check`
- repository pre-commit and pre-push hooks

## Packaging note

The Homebrew formula should install `gitai-agent` and `gitai-common.sh` alongside the command entrypoints.
