### PR TITLE
fix: trust Homebrew tap during formula bump

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Update Homebrew formula
-        uses: dawidd6/action-homebrew-bump-formula@v3
+        uses: dawidd6/action-homebrew-bump-formula@v8
         with:
           # GitHub token, required, not the default one
           token: ${{secrets.TOKEN}}


### PR DESCRIPTION
## Summary

Fix the Homebrew formula bump workflow failure caused by Homebrew rejecting `tenfyzhong/tap` as an untrusted third-party tap.

The failed run used `dawidd6/action-homebrew-bump-formula@v3`. Version 8 of the action trusts the requested tap before loading its formula, so this updates the workflow to `@v8`.

Failed run: https://github.com/tenfyzhong/gitai/actions/runs/30086459407/job/89459672590

## Changes

- upgrade `dawidd6/action-homebrew-bump-formula` from v3 to v8

## Testing

- parsed `.github/workflows/homebrew.yml` as YAML
- ran `./tests/run.sh`
- ran `git diff --check`
- passed repository pre-commit and pre-push hooks

## Release follow-up

The original `1.0.0` run remains tied to the old workflow. After this PR is merged, create a new patch tag such as `1.0.1` to trigger the corrected workflow.
